### PR TITLE
fix: render problems at small widths

### DIFF
--- a/packages/e2e/src/problems.show.ts
+++ b/packages/e2e/src/problems.show.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.show'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Locator, Panel }) => {
   // act
   await Panel.open('Problems')

--- a/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
@@ -17,7 +17,7 @@ export const getProblemsVirtualDom = (
   message: string,
 ): readonly VirtualDomNode[] => {
   const baseDom = {
-    childCount: 1,
+    childCount: isSmall ? 2 : 1,
     className: mergeClassNames(ClassNames.Viewlet, ClassNames.Problems),
     onBlur: DomEventListenerFunctions.HandleBlur,
     onContextMenu: DomEventListenerFunctions.HandleContextMenu,

--- a/packages/problems-view/test/GetProblemsVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsVirtualDom.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import { getProblemsVirtualDom } from '../src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts'
+import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
+
+test('getProblemsVirtualDom includes the filter and items as root children at small widths', () => {
+  const dom = getProblemsVirtualDom(ProblemsViewMode.List, [], '', true, 'No problems')
+
+  expect(dom[0].childCount).toBe(2)
+})
+
+test('getProblemsVirtualDom includes only the items as a root child at large widths', () => {
+  const dom = getProblemsVirtualDom(ProblemsViewMode.List, [], '', false, 'No problems')
+
+  expect(dom[0].childCount).toBe(1)
+})


### PR DESCRIPTION
Fix the Problems view root child count when the compact filter is shown. Re-enables the Problems show e2e regression test.