### PR TITLE
feature: wrap problems filenames

### DIFF
--- a/packages/e2e/src/problems.one-problem.ts
+++ b/packages/e2e/src/problems.one-problem.ts
@@ -25,6 +25,8 @@ export const test: Test = async ({ expect, Extension, FileSystem, Locator, Main,
 
   const firstProblem = problems.nth(0)
   await expect(firstProblem).toHaveText('file1.xyz1')
+  const fileName = firstProblem.locator('.Label')
+  await expect(fileName).toHaveText('file1.xyz')
 
   const secondProblem = problems.nth(1)
   await expect(secondProblem).toHaveText('error 1xyz [Ln 0, Col 0]')

--- a/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
@@ -52,6 +52,11 @@ export const getProblemVirtualDom = (problem: VisibleProblem): readonly VirtualD
         ? GetChevronVirtualDom.getChevronRightVirtualDom()
         : GetChevronVirtualDom.getChevronDownVirtualDom(),
       GetFileIconVirtualDom.getFileIconVirtualDom(icon),
+      {
+        childCount: 1,
+        className: ClassNames.Label,
+        type: VirtualDomElements.Span,
+      },
       text(fileName),
       {
         childCount: 1,

--- a/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
@@ -62,6 +62,11 @@ test('getProblemVirtualDom returns correct dom for Expanded', () => {
       type: VirtualDomElements.Img,
     },
     {
+      childCount: 1,
+      className: ClassNames.Label,
+      type: VirtualDomElements.Span,
+    },
+    {
       childCount: 0,
       text: '',
       type: 12,
@@ -125,6 +130,11 @@ test('getProblemVirtualDom returns correct dom for Collapsed', () => {
       role: AriaRoles.None,
       src: 'icon-ts',
       type: VirtualDomElements.Img,
+    },
+    {
+      childCount: 1,
+      className: ClassNames.Label,
+      type: VirtualDomElements.Span,
     },
     {
       childCount: 0,

--- a/packages/problems-view/test/GetProblemsListVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsListVirtualDom.test.ts
@@ -48,7 +48,7 @@ test('getProblemsListVirtualDom with single problem', () => {
   const problems: readonly VisibleProblem[] = [problem]
   const result = getProblemsListVirtualDom(problems)
 
-  expect(result).toHaveLength(9) // 1 container + 8 problem items
+  expect(result).toHaveLength(10) // 1 container + 9 problem items
   expect(result[0]).toEqual({
     ariaLabel: 'Problems Tree',
     childCount: 1,
@@ -112,7 +112,7 @@ test('getProblemsListVirtualDom with multiple problems', () => {
   const problems: readonly VisibleProblem[] = [problem1, problem2]
   const result = getProblemsListVirtualDom(problems)
 
-  expect(result).toHaveLength(17) // 1 container + 8 items for problem1 + 8 items for problem2
+  expect(result).toHaveLength(19) // 1 container + 9 items for problem1 + 9 items for problem2
   expect(result[0]).toEqual({
     ariaLabel: 'Problems Tree',
     childCount: 2,


### PR DESCRIPTION
Wrap Problems view filenames in their own span so each filename is independently addressable in the DOM. Adds virtual-DOM and e2e regression coverage for the wrapper.