### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     rules: {
@@ -14,6 +15,21 @@ export default [
       'unicorn/no-immediate-mutation': 'off',
       'unicorn/no-useless-template-literals': 'off',
       'unicorn/prefer-url-href': 'off',
+    },
+  },
+  {
+    files: ['packages/problems-view/test/**/*.ts'],
+    rules: {
+      'virtual-dom/no-inline-event-handlers': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: ['packages/problems-view/test/Main.test.ts'],
+    rules: {
+      'jest/expect-expect': 'off',
     },
   },
 ]

--- a/packages/problems-view/src/parts/GetMenuEntriesFilter/GetMenuEntriesFilter.ts
+++ b/packages/problems-view/src/parts/GetMenuEntriesFilter/GetMenuEntriesFilter.ts
@@ -3,23 +3,26 @@ import type { MenuEntry } from '../MenuEntry/MenuEntry.ts'
 import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
 import * as ProblemStrings from '../ProblemStrings/ProblemStrings.ts'
 
-export const getMenuEntriesFilter = (state: ProblemsState): readonly MenuEntry[] => [
-  {
-    command: '-1',
-    flags: state.showErrors ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
-    id: 'show-errors',
-    label: ProblemStrings.showErrors(),
-  },
-  {
-    command: '-1',
-    flags: state.showWarnings ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
-    id: 'show-warnings',
-    label: ProblemStrings.showWarnings(),
-  },
-  {
-    command: '-1',
-    flags: state.showInfos ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
-    id: 'show-infos',
-    label: ProblemStrings.showInfos(),
-  },
-]
+export const getMenuEntriesFilter = (state: ProblemsState): readonly MenuEntry[] => {
+  const { showErrors, showInfos, showWarnings } = state
+  return [
+    {
+      command: '-1',
+      flags: showErrors ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
+      id: 'show-errors',
+      label: ProblemStrings.showErrors(),
+    },
+    {
+      command: '-1',
+      flags: showWarnings ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
+      id: 'show-warnings',
+      label: ProblemStrings.showWarnings(),
+    },
+    {
+      command: '-1',
+      flags: showInfos ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
+      id: 'show-infos',
+      label: ProblemStrings.showInfos(),
+    },
+  ]
+}

--- a/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
@@ -8,6 +8,7 @@ import * as DomId from '../DomId/DomId.ts'
 import * as GetProblemsFilterVirtualDom from '../GetProblemsFilterVirtualDom/GetProblemsFilterVirtualDom.ts'
 import * as GetProblemsItemsVirtualDom from '../GetProblemsItemsVirtualDom/GetProblemsItemsVirtualDom.ts'
 import * as ProblemStrings from '../ProblemStrings/ProblemStrings.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 export const getProblemsVirtualDom = (
   viewMode: number,
@@ -22,7 +23,7 @@ export const getProblemsVirtualDom = (
     onBlur: DomEventListenerFunctions.HandleBlur,
     onContextMenu: DomEventListenerFunctions.HandleContextMenu,
     onPointerDown: DomEventListenerFunctions.HandlePointerDown,
-    tabIndex: 0,
+    tabIndex: TabIndex.Focusable,
     type: VirtualDomElements.Div,
   }
 

--- a/packages/problems-view/src/parts/HandleIconThemeChange/HandleIconThemeChange.ts
+++ b/packages/problems-view/src/parts/HandleIconThemeChange/HandleIconThemeChange.ts
@@ -1,8 +1,9 @@
 import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
 
 export const handleIconThemeChange = (state: ProblemsState): ProblemsState => {
+  const { problems } = state
   return {
     ...state,
-    problems: [...state.problems],
+    problems: [...problems],
   }
 }

--- a/packages/problems-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/problems-view/src/parts/LoadContent/LoadContent.ts
@@ -30,7 +30,8 @@ const getSavedCollapsedUris = (savedState: any): readonly string[] => {
 }
 
 export const loadContent = async (state: ProblemsState, savedState: any): Promise<ProblemsState> => {
-  const { error, problems } = await GetProblems.getProblems(state.workspaceUri)
+  const { workspaceUri } = state
+  const { error, problems } = await GetProblems.getProblems(workspaceUri)
   if (error) {
     return {
       ...state,

--- a/packages/problems-view/src/parts/TabIndex/TabIndex.ts
+++ b/packages/problems-view/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0

--- a/packages/problems-view/src/parts/ToggleShowErrors/ToggleShowErrors.ts
+++ b/packages/problems-view/src/parts/ToggleShowErrors/ToggleShowErrors.ts
@@ -1,8 +1,9 @@
 import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
 
 export const toggleShowErrors = (state: ProblemsState): ProblemsState => {
+  const { showErrors } = state
   return {
     ...state,
-    showErrors: !state.showErrors,
+    showErrors: !showErrors,
   }
 }

--- a/packages/problems-view/src/parts/ToggleShowInfos/ToggleShowInfos.ts
+++ b/packages/problems-view/src/parts/ToggleShowInfos/ToggleShowInfos.ts
@@ -1,8 +1,9 @@
 import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
 
 export const toggleShowInfos = (state: ProblemsState): ProblemsState => {
+  const { showInfos } = state
   return {
     ...state,
-    showInfos: !state.showInfos,
+    showInfos: !showInfos,
   }
 }

--- a/packages/problems-view/src/parts/ToggleShowWarnings/ToggleShowWarnings.ts
+++ b/packages/problems-view/src/parts/ToggleShowWarnings/ToggleShowWarnings.ts
@@ -1,8 +1,9 @@
 import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
 
 export const toggleShowWarnings = (state: ProblemsState): ProblemsState => {
+  const { showWarnings } = state
   return {
     ...state,
-    showWarnings: !state.showWarnings,
+    showWarnings: !showWarnings,
   }
 }


### PR DESCRIPTION
Enable the shared recommended virtual DOM ESLint configuration, fix the resulting production findings, and keep fixture-oriented test exceptions scoped to the problems-view tests.\n\nValidated with lint, type-check, build, unit tests, and the memory measurement.