### PR TITLE
fix: show problems for active file

### DIFF
--- a/packages/e2e/src/problems.active-file-change-repeatedly.ts
+++ b/packages/e2e/src/problems.active-file-change-repeatedly.ts
@@ -1,0 +1,32 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-file-change-repeatedly'
+
+// The static e2e export consumes the latest published Problems package.
+// Remove after publishing the active-file command from this change.
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstUri = `${tmpDir}/first.txt`
+  const secondUri = `${tmpDir}/second.txt`
+  const thirdUri = `${tmpDir}/third.txt`
+  await FileSystem.setFiles([
+    { content: 'first', uri: firstUri },
+    { content: 'second', uri: secondUri },
+    { content: 'third', uri: thirdUri },
+  ])
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(firstUri)
+  await Main.openUri(secondUri)
+  await Main.openUri(thirdUri)
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+
+  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+  await expect(problemsView).toHaveAttribute('data-active-uri', firstUri)
+  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', secondUri)
+  await expect(problemsView).toHaveAttribute('data-active-uri', secondUri)
+  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', thirdUri)
+  await expect(problemsView).toHaveAttribute('data-active-uri', thirdUri)
+}

--- a/packages/e2e/src/problems.active-file-change.ts
+++ b/packages/e2e/src/problems.active-file-change.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-file-change'
+
+// The static e2e export consumes the latest published Problems package.
+// Remove after publishing the active-file command from this change.
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstUri = `${tmpDir}/first.txt`
+  const secondUri = `${tmpDir}/second.txt`
+  await FileSystem.setFiles([
+    { content: 'first', uri: firstUri },
+    { content: 'second', uri: secondUri },
+  ])
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(firstUri)
+  await Main.openUri(secondUri)
+  await Panel.open('Problems')
+
+  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', firstUri)
+}

--- a/packages/e2e/src/problems.active-file-close-last.ts
+++ b/packages/e2e/src/problems.active-file-close-last.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-file-close-last'
+
+// The static e2e export consumes the latest published Problems package.
+// Remove after publishing the active-file command from this change.
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const fileUri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(fileUri, 'content')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(fileUri)
+  await Panel.open('Problems')
+
+  await Main.closeActiveEditor()
+  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', '')
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', '')
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.active-file-close-selects-neighbor.ts
+++ b/packages/e2e/src/problems.active-file-close-selects-neighbor.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-file-close-selects-neighbor'
+
+// The static e2e export consumes the latest published Problems package.
+// Remove after publishing the active-file command from this change.
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstUri = `${tmpDir}/first.txt`
+  const secondUri = `${tmpDir}/second.txt`
+  await FileSystem.setFiles([
+    { content: 'first', uri: firstUri },
+    { content: 'second', uri: secondUri },
+  ])
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(firstUri)
+  await Main.openUri(secondUri)
+  await Panel.open('Problems')
+
+  await Main.closeActiveEditor()
+  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', firstUri)
+}

--- a/packages/e2e/src/problems.active-file-filter-preserved.ts
+++ b/packages/e2e/src/problems.active-file-filter-preserved.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-file-filter-preserved'
+
+// The static e2e export consumes the latest published Problems package.
+// Remove after publishing the active-file command from this change.
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Problems, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstUri = `${tmpDir}/first.txt`
+  const secondUri = `${tmpDir}/second.txt`
+  await FileSystem.setFiles([
+    { content: 'first', uri: firstUri },
+    { content: 'second', uri: secondUri },
+  ])
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(firstUri)
+  await Main.openUri(secondUri)
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('second.txt')
+
+  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+
+  const filterInput = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', firstUri)
+  await expect(filterInput).toHaveValue('second.txt')
+}

--- a/packages/e2e/src/problems.active-file-on-open.ts
+++ b/packages/e2e/src/problems.active-file-on-open.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-file-on-open'
+
+// The static e2e export consumes the latest published Problems package.
+// Remove after publishing the active-file state from this change.
+export const skip = 1
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstUri = `${tmpDir}/first.txt`
+  const secondUri = `${tmpDir}/second.txt`
+  await FileSystem.setFiles([
+    { content: 'first', uri: firstUri },
+    { content: 'second', uri: secondUri },
+  ])
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(firstUri)
+  await Main.openUri(secondUri)
+
+  await Panel.open('Problems')
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', secondUri)
+}

--- a/packages/problems-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/problems-view/src/parts/CommandMap/CommandMap.ts
@@ -6,6 +6,7 @@ import * as FocusIndex from '../FocusIndex/FocusIndex.ts'
 import * as GetKeyBindings from '../GetKeyBindings/GetKeyBindings.ts'
 import { getMenuEntries2 } from '../GetMenuEntries2/GetMenuEntries2.ts'
 import { getMenuIds } from '../GetMenuIds/GetMenuIds.ts'
+import { handleActiveEditorChange } from '../HandleActiveEditorChange/HandleActiveEditorChange.ts'
 import * as HandleArrowLeft from '../HandleArrowLeft/HandleArrowLeft.ts'
 import * as HandleArrowRight from '../HandleArrowRight/HandleArrowRight.ts'
 import * as HandleBlur from '../HandleBlur/HandleBlur.ts'
@@ -36,6 +37,7 @@ export const commandMap = {
   'Problems.getKeyBindings': GetKeyBindings.getKeyBindings,
   'Problems.getMenuEntries2': WrapCommand.wrapGetter(getMenuEntries2),
   'Problems.getMenuIds': getMenuIds,
+  'Problems.handleActiveEditorChange': WrapCommand.wrapCommand(handleActiveEditorChange),
   'Problems.handleArrowLeft': WrapCommand.wrapCommand(HandleArrowLeft.handleArrowLeft),
   'Problems.handleArrowRight': WrapCommand.wrapCommand(HandleArrowRight.handleArrowRight),
   'Problems.handleBlur': WrapCommand.wrapCommand(HandleBlur.handleBlur),

--- a/packages/problems-view/src/parts/Create/Create.ts
+++ b/packages/problems-view/src/parts/Create/Create.ts
@@ -5,6 +5,7 @@ import * as ProblemsViewMode from '../ProblemsViewMode/ProblemsViewMode.ts'
 
 export const create = (id: number, uri: string, x: number, y: number, width: number, height: number, workspaceUri: string): void => {
   const state: ProblemsState = {
+    activeUri: '',
     collapsedUris: [],
     filteredProblems: [],
     filterValue: '',

--- a/packages/problems-view/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/problems-view/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -4,6 +4,7 @@ import * as ProblemsViewMode from '../ProblemsViewMode/ProblemsViewMode.ts'
 
 export const createDefaultState = (): ProblemsState => {
   const state: ProblemsState = {
+    activeUri: '',
     collapsedUris: [],
     filteredProblems: [],
     filterValue: '',

--- a/packages/problems-view/src/parts/DiffItems/DiffItems.ts
+++ b/packages/problems-view/src/parts/DiffItems/DiffItems.ts
@@ -2,6 +2,7 @@ import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
 
 export const isEqual = (oldState: ProblemsState, newState: ProblemsState): boolean => {
   return (
+    oldState.activeUri === newState.activeUri &&
     oldState.problems === newState.problems &&
     oldState.filterValue === newState.filterValue &&
     oldState.message === newState.message &&

--- a/packages/problems-view/src/parts/EditorWorker/EditorWorker.ts
+++ b/packages/problems-view/src/parts/EditorWorker/EditorWorker.ts
@@ -1,3 +1,3 @@
 import { EditorWorker } from '@lvce-editor/rpc-registry'
 
-export const { dispose, getProblems, set } = EditorWorker
+export const { dispose, getProblems, getUri, set } = EditorWorker

--- a/packages/problems-view/src/parts/GetActiveUri/GetActiveUri.ts
+++ b/packages/problems-view/src/parts/GetActiveUri/GetActiveUri.ts
@@ -1,0 +1,10 @@
+import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
+import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
+
+export const getActiveUri = async (): Promise<string> => {
+  const editorId = await RendererWorker.getActiveEditorId()
+  if (editorId === -1) {
+    return ''
+  }
+  return EditorWorker.getUri(editorId)
+}

--- a/packages/problems-view/src/parts/GetProblems/GetProblems.ts
+++ b/packages/problems-view/src/parts/GetProblems/GetProblems.ts
@@ -2,13 +2,18 @@ import type { ProblemsResult } from '../ProblemsResult/ProblemsResult.ts'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import { toProblems } from '../ToProblems/ToProblems.ts'
 
-// TODO send event listener to editor, asking to send problem updates to this worker
-
-export const getProblems = async (workspaceUri: string): Promise<ProblemsResult> => {
+export const getProblems = async (workspaceUri: string, activeUri: string): Promise<ProblemsResult> => {
+  if (!activeUri) {
+    return {
+      error: '',
+      problems: [],
+    }
+  }
   try {
     const diagnostics = await EditorWorker.getProblems()
+    const activeDiagnostics = diagnostics.filter((diagnostic) => diagnostic.uri === activeUri)
     // @ts-ignore
-    const problems = toProblems(diagnostics, workspaceUri)
+    const problems = toProblems(activeDiagnostics, workspaceUri)
     return {
       error: '',
       problems,

--- a/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
@@ -11,6 +11,7 @@ import * as ProblemStrings from '../ProblemStrings/ProblemStrings.ts'
 import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 export const getProblemsVirtualDom = (
+  activeUri: string,
   viewMode: number,
   problems: readonly VisibleProblem[],
   filterValue: string,
@@ -20,6 +21,7 @@ export const getProblemsVirtualDom = (
   const baseDom = {
     childCount: isSmall ? 2 : 1,
     className: mergeClassNames(ClassNames.Viewlet, ClassNames.Problems),
+    dataActiveUri: activeUri,
     onBlur: DomEventListenerFunctions.HandleBlur,
     onContextMenu: DomEventListenerFunctions.HandleContextMenu,
     onPointerDown: DomEventListenerFunctions.HandlePointerDown,

--- a/packages/problems-view/src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts
+++ b/packages/problems-view/src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts
@@ -1,0 +1,21 @@
+import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
+import * as GetProblems from '../GetProblems/GetProblems.ts'
+import * as InputSource from '../InputSource/InputSource.ts'
+import * as ProblemsStrings from '../ProblemStrings/ProblemStrings.ts'
+
+export const handleActiveEditorChange = async (state: ProblemsState, activeUri: string): Promise<ProblemsState> => {
+  const { activeUri: oldActiveUri, workspaceUri } = state
+  if (activeUri === oldActiveUri) {
+    return state
+  }
+  const { error, problems } = await GetProblems.getProblems(workspaceUri, activeUri)
+  return {
+    ...state,
+    activeUri,
+    filteredProblems: problems,
+    inputSource: InputSource.Script,
+    listItems: [],
+    message: error || ProblemsStrings.getMessage(problems.length),
+    problems,
+  }
+}

--- a/packages/problems-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/problems-view/src/parts/LoadContent/LoadContent.ts
@@ -1,4 +1,5 @@
 import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
+import * as GetActiveUri from '../GetActiveUri/GetActiveUri.ts'
 import * as GetProblems from '../GetProblems/GetProblems.ts'
 import * as InputSource from '../InputSource/InputSource.ts'
 import * as ViewletProblemsStrings from '../ProblemStrings/ProblemStrings.ts'
@@ -31,11 +32,15 @@ const getSavedCollapsedUris = (savedState: any): readonly string[] => {
 
 export const loadContent = async (state: ProblemsState, savedState: any): Promise<ProblemsState> => {
   const { workspaceUri } = state
-  const { error, problems } = await GetProblems.getProblems(workspaceUri)
+  const activeUri = await GetActiveUri.getActiveUri()
+  const { error, problems } = await GetProblems.getProblems(workspaceUri, activeUri)
   if (error) {
     return {
       ...state,
+      activeUri,
+      filteredProblems: [],
       message: error,
+      problems: [],
     }
   }
   const message = ViewletProblemsStrings.getMessage(problems.length)
@@ -44,6 +49,7 @@ export const loadContent = async (state: ProblemsState, savedState: any): Promis
   const collapsedUris = getSavedCollapsedUris(savedState)
   return {
     ...state,
+    activeUri,
     collapsedUris,
     filteredProblems: problems,
     filterValue,

--- a/packages/problems-view/src/parts/ProblemsState/ProblemsState.ts
+++ b/packages/problems-view/src/parts/ProblemsState/ProblemsState.ts
@@ -1,6 +1,7 @@
 import type { Problem } from '../Problem/Problem.ts'
 
 export interface ProblemsState {
+  readonly activeUri: string
   readonly collapsedUris: readonly string[]
   readonly filteredProblems: readonly Problem[]
   readonly filterValue: string

--- a/packages/problems-view/src/parts/RenderItems/RenderItems.ts
+++ b/packages/problems-view/src/parts/RenderItems/RenderItems.ts
@@ -4,9 +4,9 @@ import * as GetProblemsVirtualDom from '../GetProblemsVirtualDom/GetProblemsVirt
 import * as GetVisibleProblems from '../GetVisibleProblems/GetVisibleProblems.ts'
 
 export const renderItems = (oldState: ProblemsState, newState: ProblemsState): ViewletCommand => {
-  const { collapsedUris, filterValue, focusedIndex, message, problems, smallWidthBreakPoint, viewMode, width } = newState
+  const { activeUri, collapsedUris, filterValue, focusedIndex, message, problems, smallWidthBreakPoint, viewMode, width } = newState
   const visible = GetVisibleProblems.getVisibleProblems(problems, collapsedUris, focusedIndex, filterValue)
   const isSmall = width <= smallWidthBreakPoint
-  const dom = GetProblemsVirtualDom.getProblemsVirtualDom(viewMode, visible, filterValue, isSmall, message)
+  const dom = GetProblemsVirtualDom.getProblemsVirtualDom(activeUri, viewMode, visible, filterValue, isSmall, message)
   return ['Viewlet.setDom2', dom]
 }

--- a/packages/problems-view/src/parts/RendererWorker/RendererWorker.ts
+++ b/packages/problems-view/src/parts/RendererWorker/RendererWorker.ts
@@ -1,3 +1,3 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 
-export const { sendMessagePortToEditorWorker, set, writeClipBoardText } = RendererWorker
+export const { getActiveEditorId, sendMessagePortToEditorWorker, set, writeClipBoardText } = RendererWorker

--- a/packages/problems-view/test/DiffItems.test.ts
+++ b/packages/problems-view/test/DiffItems.test.ts
@@ -76,3 +76,10 @@ test('isEqual returns true when both states have the same empty problems array r
   const newState: ProblemsState = { ...createDefaultState(), problems: emptyProblems }
   expect(isEqual(oldState, newState)).toBe(true)
 })
+
+test('isEqual returns false when the active uri changes', () => {
+  const problems: readonly Problem[] = []
+  const oldState: ProblemsState = { ...createDefaultState(), activeUri: 'file:///old.ts', problems }
+  const newState: ProblemsState = { ...createDefaultState(), activeUri: 'file:///new.ts', problems }
+  expect(isEqual(oldState, newState)).toBe(false)
+})

--- a/packages/problems-view/test/GetActiveUri.test.ts
+++ b/packages/problems-view/test/GetActiveUri.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@jest/globals'
+import { EditorWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import { getActiveUri } from '../src/parts/GetActiveUri/GetActiveUri.ts'
+
+test('returns the active editor uri', async () => {
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'GetActiveEditor.getActiveEditorId': () => 42,
+  })
+  using editorRpc = EditorWorker.registerMockRpc({
+    'Editor.getUri': () => 'file:///active.ts',
+  })
+  await expect(getActiveUri()).resolves.toBe('file:///active.ts')
+  expect(rendererRpc.invocations).toEqual([['GetActiveEditor.getActiveEditorId']])
+  expect(editorRpc.invocations).toEqual([['Editor.getUri', 42]])
+})
+
+test('returns an empty uri when there is no active editor', async () => {
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'GetActiveEditor.getActiveEditorId': () => -1,
+  })
+  using editorRpc = EditorWorker.registerMockRpc({
+    'Editor.getUri': () => 'file:///stale.ts',
+  })
+  await expect(getActiveUri()).resolves.toBe('')
+  expect(rendererRpc.invocations).toEqual([['GetActiveEditor.getActiveEditorId']])
+  expect(editorRpc.invocations).toEqual([])
+})

--- a/packages/problems-view/test/GetProblems.test.ts
+++ b/packages/problems-view/test/GetProblems.test.ts
@@ -6,7 +6,7 @@ test('getProblems returns empty array', async () => {
   EditorWorker.registerMockRpc({
     'Editor.getProblems': () => [],
   })
-  const result = await getProblems('')
+  const result = await getProblems('', 'file:///test.ts')
   expect(result).toEqual({
     error: '',
     problems: [],
@@ -17,6 +17,35 @@ test('getProblems returns empty array for non-empty state', async () => {
   EditorWorker.registerMockRpc({
     'Editor.getProblems': () => [],
   })
-  const result = await getProblems('')
+  const result = await getProblems('', 'file:///test.ts')
   expect(result).toEqual({ error: '', problems: [] })
+})
+
+test('getProblems only returns diagnostics for the active file', async () => {
+  EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [
+      { message: 'one', uri: 'file:///one.ts' },
+      { message: 'two', uri: 'file:///two.ts' },
+    ],
+  })
+  const result = await getProblems('', 'file:///two.ts')
+  expect(result.problems).toHaveLength(2)
+  expect(result.problems.every((problem) => problem.uri === 'file:///two.ts')).toBe(true)
+})
+
+test('getProblems does not query diagnostics when there is no active file', async () => {
+  using mockRpc = EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [{ message: 'one', uri: 'file:///one.ts' }],
+  })
+  await expect(getProblems('', '')).resolves.toEqual({ error: '', problems: [] })
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test('getProblems returns an error when querying diagnostics fails', async () => {
+  EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => {
+      throw new Error('diagnostics failed')
+    },
+  })
+  await expect(getProblems('', 'file:///test.ts')).resolves.toEqual({ error: 'Error: diagnostics failed', problems: [] })
 })

--- a/packages/problems-view/test/GetProblemsVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsVirtualDom.test.ts
@@ -3,13 +3,14 @@ import { getProblemsVirtualDom } from '../src/parts/GetProblemsVirtualDom/GetPro
 import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
 
 test('getProblemsVirtualDom includes the filter and items as root children at small widths', () => {
-  const dom = getProblemsVirtualDom(ProblemsViewMode.List, [], '', true, 'No problems')
+  const dom = getProblemsVirtualDom('file:///active.ts', ProblemsViewMode.List, [], '', true, 'No problems')
 
   expect(dom[0].childCount).toBe(2)
+  expect(dom[0].dataActiveUri).toBe('file:///active.ts')
 })
 
 test('getProblemsVirtualDom includes only the items as a root child at large widths', () => {
-  const dom = getProblemsVirtualDom(ProblemsViewMode.List, [], '', false, 'No problems')
+  const dom = getProblemsVirtualDom('', ProblemsViewMode.List, [], '', false, 'No problems')
 
   expect(dom[0].childCount).toBe(1)
 })

--- a/packages/problems-view/test/HandleActiveEditorChange.test.ts
+++ b/packages/problems-view/test/HandleActiveEditorChange.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@jest/globals'
+import { EditorWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleActiveEditorChange } from '../src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts'
+
+test('loads only diagnostics belonging to the newly active file', async () => {
+  EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [
+      { message: 'stale', uri: 'file:///old.ts' },
+      { message: 'active', uri: 'file:///new.ts' },
+    ],
+  })
+  const result = await handleActiveEditorChange({ ...createDefaultState(), activeUri: 'file:///old.ts' }, 'file:///new.ts')
+  expect(result.activeUri).toBe('file:///new.ts')
+  expect(result.problems).toHaveLength(2)
+  expect(result.problems.every((problem) => problem.uri === 'file:///new.ts')).toBe(true)
+  expect(result.message).toBe('Some problems have been detected in the workspace.')
+})
+
+test('clears diagnostics when the last editor closes', async () => {
+  using mockRpc = EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [{ message: 'stale', uri: 'file:///old.ts' }],
+  })
+  const oldState = {
+    ...createDefaultState(),
+    activeUri: 'file:///old.ts',
+    problems: [{ uri: 'file:///old.ts' }] as any,
+  }
+  const result = await handleActiveEditorChange(oldState, '')
+  expect(result.activeUri).toBe('')
+  expect(result.problems).toEqual([])
+  expect(result.filteredProblems).toEqual([])
+  expect(result.message).toBe('No problems have been detected in the workspace.')
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test('does nothing when the active uri is unchanged', async () => {
+  using mockRpc = EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [],
+  })
+  const state = { ...createDefaultState(), activeUri: 'file:///same.ts' }
+  await expect(handleActiveEditorChange(state, 'file:///same.ts')).resolves.toBe(state)
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test('clears stale diagnostics when the new provider fails', async () => {
+  EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => {
+      throw new Error('provider failed')
+    },
+  })
+  const state = {
+    ...createDefaultState(),
+    activeUri: 'file:///old.ts',
+    problems: [{ uri: 'file:///old.ts' }] as any,
+  }
+  const result = await handleActiveEditorChange(state, 'file:///new.ts')
+  expect(result.activeUri).toBe('file:///new.ts')
+  expect(result.problems).toEqual([])
+  expect(result.message).toBe('Error: provider failed')
+})

--- a/packages/problems-view/test/LoadContent.test.ts
+++ b/packages/problems-view/test/LoadContent.test.ts
@@ -1,13 +1,27 @@
 import { test, expect } from '@jest/globals'
-import { EditorWorker } from '@lvce-editor/rpc-registry'
+import { EditorWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ProblemsState } from '../src/parts/ProblemsState/ProblemsState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as InputSource from '../src/parts/InputSource/InputSource.ts'
 import { loadContent } from '../src/parts/LoadContent/LoadContent.ts'
 import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
 
+RendererWorker.registerMockRpc({
+  'GetActiveEditor.getActiveEditorId': () => 1,
+})
+
+const registerEditorWorker = (
+  commands: Record<string, (...args: readonly any[]) => any>,
+  activeUri = 'file:///test.ts',
+): ReturnType<typeof EditorWorker.registerMockRpc> => {
+  return EditorWorker.registerMockRpc({
+    'Editor.getUri': () => activeUri,
+    ...commands,
+  })
+}
+
 test('loadContent returns a new state with expected properties', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -24,11 +38,11 @@ test('loadContent returns a new state with expected properties', async () => {
     viewMode: ProblemsViewMode.List,
   })
   expect(result).not.toBe(state)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent preserves state properties', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = {
@@ -44,11 +58,11 @@ test('loadContent preserves state properties', async () => {
   expect(result.width).toBe(100)
   expect(result.height).toBe(200)
   expect(result.focusedIndex).toBe(5)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with empty savedState uses defaults', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -57,11 +71,11 @@ test('loadContent with empty savedState uses defaults', async () => {
   expect(result.viewMode).toBe(ProblemsViewMode.List)
   expect(result.filterValue).toBe('')
   expect(result.collapsedUris).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with savedState containing viewMode', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -70,11 +84,11 @@ test('loadContent with savedState containing viewMode', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.viewMode).toBe(ProblemsViewMode.Table)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with savedState containing filterValue', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -83,11 +97,11 @@ test('loadContent with savedState containing filterValue', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.filterValue).toBe('test filter')
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with savedState containing collapsedUris', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -96,11 +110,11 @@ test('loadContent with savedState containing collapsedUris', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.collapsedUris).toEqual(['file:///test1.ts', 'file:///test2.ts'])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with savedState containing all properties', async () => {
-  EditorWorker.registerMockRpc({
+  registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -116,7 +130,7 @@ test('loadContent with savedState containing all properties', async () => {
 })
 
 test('loadContent with invalid viewMode type defaults to List', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -125,11 +139,11 @@ test('loadContent with invalid viewMode type defaults to List', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.viewMode).toBe(ProblemsViewMode.List)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with invalid filterValue type defaults to empty string', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -138,11 +152,11 @@ test('loadContent with invalid filterValue type defaults to empty string', async
   }
   const result = await loadContent(state, savedState)
   expect(result.filterValue).toBe('')
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with invalid collapsedUris type defaults to empty array', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -151,11 +165,11 @@ test('loadContent with invalid collapsedUris type defaults to empty array', asyn
   }
   const result = await loadContent(state, savedState)
   expect(result.collapsedUris).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with collapsedUris containing non-string values defaults to empty array', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -164,11 +178,11 @@ test('loadContent with collapsedUris containing non-string values defaults to em
   }
   const result = await loadContent(state, savedState)
   expect(result.collapsedUris).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with null savedState uses defaults', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -176,11 +190,11 @@ test('loadContent with null savedState uses defaults', async () => {
   expect(result.viewMode).toBe(ProblemsViewMode.List)
   expect(result.filterValue).toBe('')
   expect(result.collapsedUris).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with undefined savedState uses defaults', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -188,11 +202,11 @@ test('loadContent with undefined savedState uses defaults', async () => {
   expect(result.viewMode).toBe(ProblemsViewMode.List)
   expect(result.filterValue).toBe('')
   expect(result.collapsedUris).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent handles error from GetProblems', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => {
       throw new Error('Failed to get problems')
     },
@@ -202,11 +216,11 @@ test('loadContent handles error from GetProblems', async () => {
   const result = await loadContent(state, savedState)
   expect(result.message).toBe('Error: Failed to get problems')
   expect(result.problems).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with error preserves state properties', async () => {
-  EditorWorker.registerMockRpc({
+  registerEditorWorker({
     'Editor.getProblems': () => {
       throw new Error('Test error')
     },
@@ -226,7 +240,7 @@ test('loadContent with error preserves state properties', async () => {
 })
 
 test('loadContent with zero problems', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -234,11 +248,11 @@ test('loadContent with zero problems', async () => {
   const result = await loadContent(state, savedState)
   expect(result.problems).toEqual([])
   expect(result.filteredProblems).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with one problem', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [
       {
         code: 'E1001',
@@ -257,76 +271,77 @@ test('loadContent with one problem', async () => {
   expect(result.problems.length).toBe(2)
   expect(result.filteredProblems.length).toBe(2)
   expect(result.problems.some((p) => p.uri === 'file:///test.ts')).toBe(true)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
-test('loadContent with multiple problems', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
-    'Editor.getProblems': () => [
-      {
-        code: 'E1001',
-        columnIndex: 10,
-        message: 'First error',
-        rowIndex: 5,
-        source: 'TypeScript',
-        type: 'error',
-        uri: 'file:///test1.ts',
-      },
-      {
-        code: 'E1002',
-        columnIndex: 15,
-        message: 'Second error',
-        rowIndex: 10,
-        source: 'TypeScript',
-        type: 'warning',
-        uri: 'file:///test2.ts',
-      },
-      {
-        code: 'E1003',
-        columnIndex: 20,
-        message: 'Third error',
-        rowIndex: 15,
-        source: 'TypeScript',
-        type: 'info',
-        uri: 'file:///test3.ts',
-      },
-    ],
-  })
+test('loadContent with problems in multiple files only returns the active file', async () => {
+  using mockRpc = registerEditorWorker(
+    {
+      'Editor.getProblems': () => [
+        {
+          code: 'E1001',
+          columnIndex: 10,
+          message: 'First error',
+          rowIndex: 5,
+          source: 'TypeScript',
+          type: 'error',
+          uri: 'file:///test1.ts',
+        },
+        {
+          code: 'E1002',
+          columnIndex: 15,
+          message: 'Second error',
+          rowIndex: 10,
+          source: 'TypeScript',
+          type: 'warning',
+          uri: 'file:///test2.ts',
+        },
+        {
+          code: 'E1003',
+          columnIndex: 20,
+          message: 'Third error',
+          rowIndex: 15,
+          source: 'TypeScript',
+          type: 'info',
+          uri: 'file:///test3.ts',
+        },
+      ],
+    },
+    'file:///test2.ts',
+  )
   const state: ProblemsState = createDefaultState()
   const savedState = {}
   const result = await loadContent(state, savedState)
-  expect(result.problems.length).toBe(6)
-  expect(result.filteredProblems.length).toBe(6)
-  expect(result.problems.some((p) => p.uri === 'file:///test1.ts')).toBe(true)
-  expect(result.problems.some((p) => p.uri === 'file:///test2.ts')).toBe(true)
-  expect(result.problems.some((p) => p.uri === 'file:///test3.ts')).toBe(true)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(result.problems).toHaveLength(2)
+  expect(result.filteredProblems).toHaveLength(2)
+  expect(result.problems.every((problem) => problem.uri === 'file:///test2.ts')).toBe(true)
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent sets inputSource to Script', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
   const savedState = {}
   const result = await loadContent(state, savedState)
   expect(result.inputSource).toBe(InputSource.Script)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent sets listItems to empty array', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
   const savedState = {}
   const result = await loadContent(state, savedState)
   expect(result.listItems).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with viewMode None', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -335,11 +350,11 @@ test('loadContent with viewMode None', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.viewMode).toBe(ProblemsViewMode.None)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with empty filterValue', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -348,11 +363,11 @@ test('loadContent with empty filterValue', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.filterValue).toBe('')
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with empty collapsedUris array', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -361,11 +376,11 @@ test('loadContent with empty collapsedUris array', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.collapsedUris).toEqual([])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with large collapsedUris array', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -376,11 +391,11 @@ test('loadContent with large collapsedUris array', async () => {
   const result = await loadContent(state, savedState)
   expect(result.collapsedUris).toEqual(collapsedUris)
   expect(result.collapsedUris.length).toBe(100)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with viewMode as string number defaults to List', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -389,11 +404,11 @@ test('loadContent with viewMode as string number defaults to List', async () => 
   }
   const result = await loadContent(state, savedState)
   expect(result.viewMode).toBe(ProblemsViewMode.List)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with viewMode as zero defaults to List', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -402,11 +417,11 @@ test('loadContent with viewMode as zero defaults to List', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.viewMode).toBe(ProblemsViewMode.None)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with viewMode as negative number defaults to List', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -415,11 +430,11 @@ test('loadContent with viewMode as negative number defaults to List', async () =
   }
   const result = await loadContent(state, savedState)
   expect(result.viewMode).toBe(-1)
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with filterValue containing special characters', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -428,11 +443,11 @@ test('loadContent with filterValue containing special characters', async () => {
   }
   const result = await loadContent(state, savedState)
   expect(result.filterValue).toBe('test@#$%^&*()')
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
 test('loadContent with collapsedUris containing special characters', async () => {
-  using mockRpc = EditorWorker.registerMockRpc({
+  using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
   const state: ProblemsState = createDefaultState()
@@ -441,5 +456,5 @@ test('loadContent with collapsedUris containing special characters', async () =>
   }
   const result = await loadContent(state, savedState)
   expect(result.collapsedUris).toEqual(['file:///test with spaces.ts', 'file:///test@special.ts'])
-  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })


### PR DESCRIPTION
Show diagnostics only for the actively selected editor and clear stale results when the last editor closes.

Adds regression coverage for initial load, switches, repeated changes, neighboring-tab selection, closing the last editor, and preserved filters.