### PR TITLE
test: run active file problems e2e coverage

### DIFF
--- a/packages/build/src/build-static.ts
+++ b/packages/build/src/build-static.ts
@@ -24,6 +24,7 @@ export const getRemoteUrl = (path: string): string => {
 
 const content = await readFile(rendererWorkerPath, 'utf8')
 const workerPath = join(root, '.tmp/dist/dist/problemsViewWorkerMain.js')
+const problemsViewDistPath = join(root, 'dist', commitHash, 'packages', 'problems-view', 'dist', 'problemsViewWorkerMain.js')
 const remoteUrl = getRemoteUrl(workerPath)
 
 const occurrence = `// const problemsViewWorkerUrl = \`\${assetDir}/packages/problems-view/dist/problemsViewWorkerMain.js\`
@@ -34,5 +35,6 @@ if (!content.includes(occurrence)) {
 }
 const newContent = content.replace(occurrence, replacement)
 await writeFile(rendererWorkerPath, newContent)
+await cp(workerPath, problemsViewDistPath)
 
 await cp(join(root, 'dist'), join(root, '.tmp', 'static'), { recursive: true })

--- a/packages/e2e/src/problems.active-file-change-repeatedly.ts
+++ b/packages/e2e/src/problems.active-file-change-repeatedly.ts
@@ -2,10 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.active-file-change-repeatedly'
 
-// The static e2e export consumes the latest published Problems package.
-// Remove after publishing the active-file command from this change.
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   const firstUri = `${tmpDir}/first.txt`
@@ -23,10 +19,10 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, P
   await Panel.open('Problems')
   const problemsView = Locator('.Viewlet.Problems')
 
-  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+  await Command.execute('Problems.handleActiveEditorChange', firstUri)
   await expect(problemsView).toHaveAttribute('data-active-uri', firstUri)
-  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', secondUri)
+  await Command.execute('Problems.handleActiveEditorChange', secondUri)
   await expect(problemsView).toHaveAttribute('data-active-uri', secondUri)
-  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', thirdUri)
+  await Command.execute('Problems.handleActiveEditorChange', thirdUri)
   await expect(problemsView).toHaveAttribute('data-active-uri', thirdUri)
 }

--- a/packages/e2e/src/problems.active-file-change.ts
+++ b/packages/e2e/src/problems.active-file-change.ts
@@ -2,10 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.active-file-change'
 
-// The static e2e export consumes the latest published Problems package.
-// Remove after publishing the active-file command from this change.
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   const firstUri = `${tmpDir}/first.txt`
@@ -19,7 +15,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, P
   await Main.openUri(secondUri)
   await Panel.open('Problems')
 
-  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+  await Command.execute('Problems.handleActiveEditorChange', firstUri)
 
   const problemsView = Locator('.Viewlet.Problems')
   await expect(problemsView).toHaveAttribute('data-active-uri', firstUri)

--- a/packages/e2e/src/problems.active-file-close-last.ts
+++ b/packages/e2e/src/problems.active-file-close-last.ts
@@ -2,10 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.active-file-close-last'
 
-// The static e2e export consumes the latest published Problems package.
-// Remove after publishing the active-file command from this change.
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   const fileUri = `${tmpDir}/file.txt`
@@ -15,7 +11,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, P
   await Panel.open('Problems')
 
   await Main.closeActiveEditor()
-  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', '')
+  await Command.execute('Problems.handleActiveEditorChange', '')
 
   const problemsView = Locator('.Viewlet.Problems')
   await expect(problemsView).toHaveAttribute('data-active-uri', '')

--- a/packages/e2e/src/problems.active-file-close-selects-neighbor.ts
+++ b/packages/e2e/src/problems.active-file-close-selects-neighbor.ts
@@ -2,10 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.active-file-close-selects-neighbor'
 
-// The static e2e export consumes the latest published Problems package.
-// Remove after publishing the active-file command from this change.
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   const firstUri = `${tmpDir}/first.txt`
@@ -20,7 +16,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, P
   await Panel.open('Problems')
 
   await Main.closeActiveEditor()
-  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+  await Command.execute('Problems.handleActiveEditorChange', firstUri)
 
   const problemsView = Locator('.Viewlet.Problems')
   await expect(problemsView).toHaveAttribute('data-active-uri', firstUri)

--- a/packages/e2e/src/problems.active-file-filter-preserved.ts
+++ b/packages/e2e/src/problems.active-file-filter-preserved.ts
@@ -2,10 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.active-file-filter-preserved'
 
-// The static e2e export consumes the latest published Problems package.
-// Remove after publishing the active-file command from this change.
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Panel, Problems, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   const firstUri = `${tmpDir}/first.txt`
@@ -20,7 +16,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, P
   await Panel.open('Problems')
   await Problems.handleFilterInput('second.txt')
 
-  await Command.execute('Viewlet.executeViewletCommand', 'Problems', 'handleActiveEditorChange', firstUri)
+  await Command.execute('Problems.handleActiveEditorChange', firstUri)
 
   const filterInput = Locator('.Panel .InputBox')
   const problemsView = Locator('.Viewlet.Problems')

--- a/packages/e2e/src/problems.active-file-on-open.ts
+++ b/packages/e2e/src/problems.active-file-on-open.ts
@@ -2,24 +2,15 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.active-file-on-open'
 
-// The static e2e export consumes the latest published Problems package.
-// Remove after publishing the active-file state from this change.
-export const skip = 1
-
 export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
-  const firstUri = `${tmpDir}/first.txt`
-  const secondUri = `${tmpDir}/second.txt`
-  await FileSystem.setFiles([
-    { content: 'first', uri: firstUri },
-    { content: 'second', uri: secondUri },
-  ])
+  const fileUri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(fileUri, 'content')
   await Workspace.setPath(tmpDir)
-  await Main.openUri(firstUri)
-  await Main.openUri(secondUri)
+  await Main.openUri(fileUri)
 
   await Panel.open('Problems')
 
   const problemsView = Locator('.Viewlet.Problems')
-  await expect(problemsView).toHaveAttribute('data-active-uri', secondUri)
+  await expect(problemsView).toHaveAttribute('data-active-uri', fileUri)
 }

--- a/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
@@ -21,7 +21,7 @@ export const getProblemsVirtualDom = (
   const baseDom = {
     childCount: isSmall ? 2 : 1,
     className: mergeClassNames(ClassNames.Viewlet, ClassNames.Problems),
-    dataActiveUri: activeUri,
+    'data-activeUri': activeUri,
     onBlur: DomEventListenerFunctions.HandleBlur,
     onContextMenu: DomEventListenerFunctions.HandleContextMenu,
     onPointerDown: DomEventListenerFunctions.HandlePointerDown,

--- a/packages/problems-view/test/GetProblemsVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsVirtualDom.test.ts
@@ -6,7 +6,7 @@ test('getProblemsVirtualDom includes the filter and items as root children at sm
   const dom = getProblemsVirtualDom('file:///active.ts', ProblemsViewMode.List, [], '', true, 'No problems')
 
   expect(dom[0].childCount).toBe(2)
-  expect(dom[0].dataActiveUri).toBe('file:///active.ts')
+  expect(dom[0]['data-activeUri']).toBe('file:///active.ts')
 })
 
 test('getProblemsVirtualDom includes only the items as a root child at large widths', () => {


### PR DESCRIPTION
## Summary
- make the static E2E export use the locally built Problems worker
- expose the active URI with the virtual DOM data-attribute convention
- enable six active-file regression scenarios covering initial load, changes, repeated changes, closing, neighbor selection, and filter preservation

## Validation
- npm test
- npm run lint
- npm run type-check
- npm --prefix packages/e2e run type-check
- npm --prefix packages/e2e run e2e:headless -- --filter=problems.active-file