### PR TITLE
fix: normalize problem relative paths

### DIFF
--- a/packages/problems-view/src/parts/ToProblems/ToProblems.ts
+++ b/packages/problems-view/src/parts/ToProblems/ToProblems.ts
@@ -29,7 +29,7 @@ const normalizeFileUri = (uri: string): string => {
 
 const getRelativeParentUri = (uri: string, workspaceUri: string): string => {
   const normalizedUri = normalizeFileUri(uri)
-  const normalizedWorkspaceUri = normalizeFileUri(workspaceUri).replace(/\/+$/, '')
+  const normalizedWorkspaceUri = normalizeFileUri(workspaceUri).replace(/\/$/, '')
   const slashIndex = normalizedUri.lastIndexOf('/')
   const parentUri = normalizedUri.slice(0, slashIndex)
   if (parentUri === normalizedWorkspaceUri) {

--- a/packages/problems-view/src/parts/ToProblems/ToProblems.ts
+++ b/packages/problems-view/src/parts/ToProblems/ToProblems.ts
@@ -22,9 +22,23 @@ const toProblem = (diagnostic: Diagnostic, index: number): Problem => {
   }
 }
 
+const normalizeFileUri = (uri: string): string => {
+  const normalizedUri = uri.startsWith('file://') ? uri.slice('file://'.length) : uri
+  return /^\/[a-z]:\//i.test(normalizedUri) ? normalizedUri.slice(1) : normalizedUri
+}
+
 const getRelativeParentUri = (uri: string, workspaceUri: string): string => {
-  const slashIndex = uri.lastIndexOf('/')
-  return uri.slice(0, slashIndex).slice(workspaceUri.length)
+  const normalizedUri = normalizeFileUri(uri)
+  const normalizedWorkspaceUri = normalizeFileUri(workspaceUri).replace(/\/+$/, '')
+  const slashIndex = normalizedUri.lastIndexOf('/')
+  const parentUri = normalizedUri.slice(0, slashIndex)
+  if (parentUri === normalizedWorkspaceUri) {
+    return ''
+  }
+  if (normalizedWorkspaceUri && parentUri.startsWith(`${normalizedWorkspaceUri}/`)) {
+    return parentUri.slice(normalizedWorkspaceUri.length + 1)
+  }
+  return parentUri.replace(/^\/+/, '')
 }
 
 const getFileName = (uri: string): string => {

--- a/packages/problems-view/test/ToProblems.test.ts
+++ b/packages/problems-view/test/ToProblems.test.ts
@@ -66,7 +66,9 @@ test.each([
     {
       code: 'TS2307',
       columnIndex: 42,
+      listItemType: 0,
       message: 'Cannot find module',
+      relativePath: '',
       rowIndex: 0,
       source: 'TypeScript',
       type: 'error',

--- a/packages/problems-view/test/ToProblems.test.ts
+++ b/packages/problems-view/test/ToProblems.test.ts
@@ -52,6 +52,34 @@ test('toProblems maps a single diagnostic to a header item and a problem item', 
   ])
 })
 
+test.each([
+  {
+    diagnosticUri: '/workspace/packages/running-extensions-view/src/parts/DisableWorkspace/DisableWorkspace.ts',
+    workspaceUri: 'file:///workspace',
+  },
+  {
+    diagnosticUri: 'file:///workspace/packages/running-extensions-view/src/parts/DisableWorkspace/DisableWorkspace.ts',
+    workspaceUri: '/workspace',
+  },
+])('toProblems normalizes file URIs when computing relative paths', ({ diagnosticUri, workspaceUri }) => {
+  const diagnostics = [
+    {
+      code: 'TS2307',
+      columnIndex: 42,
+      message: 'Cannot find module',
+      rowIndex: 0,
+      source: 'TypeScript',
+      type: 'error',
+      uri: diagnosticUri,
+    },
+  ]
+
+  const problems = toProblems(diagnostics, workspaceUri)
+
+  expect(problems[0].relativePath).toBe('packages/running-extensions-view/src/parts/DisableWorkspace')
+  expect(problems[1].relativePath).toBe('packages/running-extensions-view/src/parts/DisableWorkspace')
+})
+
 test('toProblems falls back to default item values for missing diagnostic fields', () => {
   const diagnostics = [
     {


### PR DESCRIPTION
Normalize file URIs and filesystem paths before deriving Problems view label details, preventing workspace path prefixes such as `packages` from being cut off.