### PR TITLE
feature: update eslint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "MIT",
       "devDependencies": {
         "@lerna/legacy-package-management": "^8.2.4",
-        "@lvce-editor/eslint-config": "^17.1.0",
-        "eslint": "^10.7.0",
+        "@lvce-editor/eslint-config": "^17.5.0",
+        "eslint": "^10.8.0",
         "lerna": "^8.2.3",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3"
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1699,11 +1699,14 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.1.0.tgz",
-      "integrity": "sha512-lmlYdyCFgw3RLz5FlFLjhfmiKZZMLrZP2fcyGIcs35LGlFkb/uDSub4RKBjPOPH0vl89NczKiO4tcoc7bL6gwA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.5.0.tgz",
+      "integrity": "sha512-wjDaVd24PNVZdjbV8EcQYrbEWsKAJ9mak03EUIMTT6+tHVwlg9G1P2eDvqpxyMSmY3ywBKhAPigEjY2pwnCGUQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@cspell/eslint-plugin": "10.0.1",
         "@e18e/eslint-plugin": "^0.5.1",
@@ -1711,14 +1714,15 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "17.1.0",
-        "@lvce-editor/eslint-plugin-e2e": "17.1.0",
-        "@lvce-editor/eslint-plugin-github-actions": "17.1.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "17.1.0",
-        "@lvce-editor/eslint-plugin-regex": "17.1.0",
-        "@lvce-editor/eslint-plugin-rpc": "17.1.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "17.1.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "17.1.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.5.0",
+        "@lvce-editor/eslint-plugin-e2e": "17.5.0",
+        "@lvce-editor/eslint-plugin-extension-json": "17.5.0",
+        "@lvce-editor/eslint-plugin-github-actions": "17.5.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.5.0",
+        "@lvce-editor/eslint-plugin-regex": "17.5.0",
+        "@lvce-editor/eslint-plugin-rpc": "17.5.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.5.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.5.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -1733,9 +1737,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.1.0.tgz",
-      "integrity": "sha512-3q55rrK9/35lwmjFjgHs7w3RBFx4MNUZ+ed0s6P5F05slSwvt0QAqky7jKxfYvQJLOBClPnkTNPQRKWDgmZESA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.5.0.tgz",
+      "integrity": "sha512-wNemW3CGngT/bRzB2ldVWW5++V/Xq549Hkbf7ZCc00XGxJhupZKTAYL3qCQvpdT5OJTUFc58Z9ddg42OLVENiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1743,16 +1747,26 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.1.0.tgz",
-      "integrity": "sha512-SphJpwEnzn9/JolZNiGe0dPPt73gHLis0/f8JoI1A7jFrhilHm76t1FN123ZgLvzqDK9mIoMw83LPXQTWtpc0A==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.5.0.tgz",
+      "integrity": "sha512-xGWeOY+aitgaKgxCVeRSJfEWMLf39u5wnq0uA3ZnZKFWXEHpZO3CaJi+9rw7KgFK7TcqgpxsaAHTENYEoabJHQ==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/eslint-plugin-extension-json": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.5.0.tgz",
+      "integrity": "sha512-F7qOAYW1LhFntc2f5Yn1QQqArqgVLi1tW6vRNzgWIptlrZTib0cGFG4jKOL7ZgB5uDl0mZWlZ9q1Q1T055eWhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.1.0.tgz",
-      "integrity": "sha512-Y7oaTDCdqOHEnDp2WjTk9eLSY8v9DzMRXip95Du4oR3hZGxa9jJvs0BTo3AuaxM8O+PN/qGeMVgFpouvmCbybg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.5.0.tgz",
+      "integrity": "sha512-RhphHPbVQHqRu2yAZ/XnUdpP67BbPrIIrAvdkqSnitCVu65DDTTN1YVZMNdNv8cYue8V3V8eUMIf8WaNFBdJEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1761,9 +1775,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.1.0.tgz",
-      "integrity": "sha512-IkCHqK4tqA3cJzzMzxh2KRnU4cjZfpDX4RtXu5yCKnhjw7SOtFDB2z8RYb8R/OpSp+tJq3q/m7N2C/HIIxNygg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.5.0.tgz",
+      "integrity": "sha512-mYcLlKt8Y2wKlM13xFXKaYDvKDOj/O5nnfj51oW7UTItROxtlD848eaXcxpLrH5iLTW5wC3G3Oz9ftwoGmqq7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1784,23 +1798,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.1.0.tgz",
-      "integrity": "sha512-PqCksBaTWrUpdeCBrw0PJLCZTgK13X672Hn2RxAf93NuD7esrrOkYhu4b0PpHK/pK94+u/cM0o6OcH8LH9umaA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.5.0.tgz",
+      "integrity": "sha512-PER04Hz35vvDFWXPK9wkSyAXB/H5aGGPE6i8nesbmGUP43fqT+7f9Kf5wzRUbUOdZ8HuFcnVQZALMbaEe1NcSg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.1.0.tgz",
-      "integrity": "sha512-ndssBmTP1olTtKO/8KCpIzibQR51GEOG3r0gTxk8CuuTNy1O/2+ikM+rw1jpOveTygK7B+wwYBrzZ3wIYbvsRQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.5.0.tgz",
+      "integrity": "sha512-7dfk74/7pFDK2fWnDK1M8OP46ehlMiK2TlOZYvsg3kU0J4dC0m7emnwvWKCgzyd/rNVPsTyqcz8PSM3U+4Lf4Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.1.0.tgz",
-      "integrity": "sha512-CVAXPVkoHnsTO4hU+P8cSApFTYVBdy1f+w38+06Z4Mp9sXC4A2VqDI8zXyhPG1XOtaLySpz9K8BpXzDWNUMtaw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.5.0.tgz",
+      "integrity": "sha512-505lmJeM12Bq5eTZ5FMjB7qmbSu0Xi8bjVCbBSjyMNAVhCAiEUfuWXq0TeiJFeT40GzF88On0GPYHxS+dviWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1808,9 +1822,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.1.0.tgz",
-      "integrity": "sha512-821gJ8uqAeUAzDkhhoCvdiH11+7BvRt4zo+M/OdZmSnj/Dfqx9Uvj6YHRq8AupM57WL9EA7czgpJe8f89tnG1w==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.5.0.tgz",
+      "integrity": "sha512-sGiPawCOnR4E/8Bb+NTLlPpmvYS/t2vYrPwoG9/KVUq6gRnj3M34pQw2vsxP9A+PYig5LeL9TX5Wjj//DYVpXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5069,9 +5083,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -5081,7 +5095,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -5105,7 +5119,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "@lerna/legacy-package-management": "^8.2.4",
-    "@lvce-editor/eslint-config": "^17.1.0",
-    "eslint": "^10.7.0",
+    "@lvce-editor/eslint-config": "^17.5.0",
+    "eslint": "^10.8.0",
     "lerna": "^8.2.3",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3"


### PR DESCRIPTION
Updates `eslint` to 10.8.0 and `@lvce-editor/eslint-config` to 17.5.0.

Validation:
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`
- `npm run build:static`