### PR TITLE
fix: display one-based problem locations

### DIFF
--- a/packages/e2e/src/problems.collapse-all.ts
+++ b/packages/e2e/src/problems.collapse-all.ts
@@ -27,5 +27,5 @@ export const test: Test = async ({ expect, Extension, FileSystem, Locator, Main,
   await expect(firstProblem).toHaveText('file1.xyz1')
 
   const secondProblem = problems.nth(1)
-  await expect(secondProblem).toHaveText('error 1xyz [Ln 0, Col 0]')
+  await expect(secondProblem).toHaveText('error 1xyz [Ln 1, Col 1]')
 }

--- a/packages/e2e/src/problems.one-problem.ts
+++ b/packages/e2e/src/problems.one-problem.ts
@@ -29,5 +29,5 @@ export const test: Test = async ({ expect, Extension, FileSystem, Locator, Main,
   await expect(fileName).toHaveText('file1.xyz')
 
   const secondProblem = problems.nth(1)
-  await expect(secondProblem).toHaveText('error 1xyz [Ln 0, Col 0]')
+  await expect(secondProblem).toHaveText('error 1xyz [Ln 1, Col 1]')
 }

--- a/packages/e2e/src/problems.view-as-table.ts
+++ b/packages/e2e/src/problems.view-as-table.ts
@@ -20,7 +20,7 @@ export const test: Test = async ({ Command, expect, Extension, FileSystem, Locat
   const firstProblem = problems.nth(0)
   await expect(firstProblem).toHaveText('file1.xyz1')
   const secondProblem = problems.nth(1)
-  await expect(secondProblem).toHaveText('error 1xyz [Ln 0, Col 0]')
+  await expect(secondProblem).toHaveText('error 1xyz [Ln 1, Col 1]')
 
   // act
   await Command.execute('Problems.viewAsTable')

--- a/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
@@ -84,7 +84,7 @@ export const getProblemVirtualDom = (problem: VisibleProblem): readonly VirtualD
       ...GetBadgeVirtualDom.getBadgeVirtualDom(ClassNames.ProblemBadge, problem.count),
     ]
   }
-  const lineColumn = ViewletProblemsStrings.atLineColumn(rowIndex, columnIndex)
+  const lineColumn = ViewletProblemsStrings.atLineColumn(rowIndex + 1, columnIndex + 1)
   const label = {
     childCount: 1,
     className: ClassNames.ProblemLabel,

--- a/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
@@ -214,11 +214,31 @@ test('getProblemVirtualDom returns correct dom for Item without filter highlight
     },
     {
       childCount: 0,
-      text: '[Ln 10, Col 5]',
+      text: '[Ln 11, Col 6]',
       type: 12,
     },
   ]
   expect(dom).toEqual(expectedDom)
+})
+
+test('getProblemVirtualDom displays zero-based diagnostic indexes as one-based coordinates', () => {
+  const problem: VisibleProblem = {
+    ...baseProblem,
+    columnIndex: 0,
+    filterValueLength: 0,
+    icon: 'icon-ts',
+    isActive: false,
+    isCollapsed: false,
+    isEven: false,
+    listItemType: ProblemListItemType.Item,
+    rowIndex: 0,
+  }
+  const dom = getProblemVirtualDom(problem)
+  expect(dom.at(-1)).toEqual({
+    childCount: 0,
+    text: '[Ln 1, Col 1]',
+    type: VirtualDomElements.Text,
+  })
 })
 
 test('getProblemVirtualDom returns correct dom for Item with filter highlight', () => {
@@ -287,7 +307,7 @@ test('getProblemVirtualDom returns correct dom for Item with filter highlight', 
     },
     {
       childCount: 0,
-      text: '[Ln 10, Col 5]',
+      text: '[Ln 11, Col 6]',
       type: 12,
     },
   ]


### PR DESCRIPTION
## Summary
- convert zero-based diagnostic indexes to one-based coordinates only at the Problems list presentation boundary
- keep internal row/column indexes unchanged for editor navigation
- update unit and browser expectations for `[Ln 1, Col 1]`

## Root cause
The Problems list formatted internal `rowIndex` and `columnIndex` values directly. Those values are intentionally zero-based, but the user-facing label must be one-based.

## Validation
- 290 unit tests passed, 1 todo
- focused `(0,0)` -> `[Ln 1, Col 1]` regression passed
- type-check passed
- lint and formatting passed
- build passed
- 32 end-to-end tests passed, 5 pre-existing tests skipped