### PR TITLE
fix: refresh problems when diagnostics change

### DIFF
--- a/packages/problems-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/problems-view/src/parts/CommandMap/CommandMap.ts
@@ -6,7 +6,7 @@ import * as FocusIndex from '../FocusIndex/FocusIndex.ts'
 import * as GetKeyBindings from '../GetKeyBindings/GetKeyBindings.ts'
 import { getMenuEntries2 } from '../GetMenuEntries2/GetMenuEntries2.ts'
 import { getMenuIds } from '../GetMenuIds/GetMenuIds.ts'
-import { handleActiveEditorChange } from '../HandleActiveEditorChange/HandleActiveEditorChange.ts'
+import { handleActiveEditorChange, handleDiagnosticsChange } from '../HandleActiveEditorChange/HandleActiveEditorChange.ts'
 import * as HandleArrowLeft from '../HandleArrowLeft/HandleArrowLeft.ts'
 import * as HandleArrowRight from '../HandleArrowRight/HandleArrowRight.ts'
 import * as HandleBlur from '../HandleBlur/HandleBlur.ts'
@@ -49,6 +49,7 @@ export const commandMap = {
   'Problems.handleClickButton': WrapCommand.wrapCommand(handleClickButton),
   'Problems.handleClickMoreFilters': WrapCommand.wrapCommand(handleClickMoreFilters),
   'Problems.handleContextMenu': WrapCommand.wrapCommand(handleContextMenu),
+  'Problems.handleDiagnosticsChange': WrapCommand.wrapCommand(handleDiagnosticsChange),
   'Problems.handleFilterInput': WrapCommand.wrapCommand(HandleFilterInput.handleFilterInput),
   'Problems.handleIconThemeChange': WrapCommand.wrapCommand(handleIconThemeChange),
   'Problems.handleScrollBarCaptureLost': WrapCommand.wrapCommand(handleScrollBarCaptureLost),

--- a/packages/problems-view/src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts
+++ b/packages/problems-view/src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts
@@ -3,11 +3,8 @@ import * as GetProblems from '../GetProblems/GetProblems.ts'
 import * as InputSource from '../InputSource/InputSource.ts'
 import * as ProblemsStrings from '../ProblemStrings/ProblemStrings.ts'
 
-export const handleActiveEditorChange = async (state: ProblemsState, activeUri: string): Promise<ProblemsState> => {
-  const { activeUri: oldActiveUri, workspaceUri } = state
-  if (activeUri === oldActiveUri) {
-    return state
-  }
+const refreshProblems = async (state: ProblemsState, activeUri: string): Promise<ProblemsState> => {
+  const { workspaceUri } = state
   const { error, problems } = await GetProblems.getProblems(workspaceUri, activeUri)
   return {
     ...state,
@@ -18,4 +15,20 @@ export const handleActiveEditorChange = async (state: ProblemsState, activeUri: 
     message: error || ProblemsStrings.getMessage(problems.length),
     problems,
   }
+}
+
+export const handleActiveEditorChange = async (state: ProblemsState, activeUri: string): Promise<ProblemsState> => {
+  const { activeUri: oldActiveUri } = state
+  if (activeUri === oldActiveUri) {
+    return state
+  }
+  return refreshProblems(state, activeUri)
+}
+
+export const handleDiagnosticsChange = async (state: ProblemsState, uri: string): Promise<ProblemsState> => {
+  const { activeUri } = state
+  if (uri !== activeUri) {
+    return state
+  }
+  return refreshProblems(state, uri)
 }

--- a/packages/problems-view/test/HandleActiveEditorChange.test.ts
+++ b/packages/problems-view/test/HandleActiveEditorChange.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jest/globals'
 import { EditorWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
-import { handleActiveEditorChange } from '../src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts'
+import { handleActiveEditorChange, handleDiagnosticsChange } from '../src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts'
 
 test('loads only diagnostics belonging to the newly active file', async () => {
   EditorWorker.registerMockRpc({
@@ -58,4 +58,33 @@ test('clears stale diagnostics when the new provider fails', async () => {
   expect(result.activeUri).toBe('file:///new.ts')
   expect(result.problems).toEqual([])
   expect(result.message).toBe('Error: provider failed')
+})
+
+test('refreshes problems when diagnostics for the active uri change', async () => {
+  using mockRpc = EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [{ message: 'updated', uri: 'file:///active.ts' }],
+  })
+  const state = {
+    ...createDefaultState(),
+    activeUri: 'file:///active.ts',
+    problems: [{ message: 'stale', uri: 'file:///active.ts' }] as any,
+  }
+
+  const result = await handleDiagnosticsChange(state, 'file:///active.ts')
+
+  expect(result).not.toBe(state)
+  expect(result.problems).toHaveLength(2)
+  expect(result.problems.every((problem) => problem.uri === 'file:///active.ts')).toBe(true)
+  expect(result.problems[1].message).toBe('updated')
+  expect(mockRpc.invocations).toEqual([['Editor.getProblems']])
+})
+
+test('ignores diagnostics changes for an inactive uri', async () => {
+  using mockRpc = EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [],
+  })
+  const state = { ...createDefaultState(), activeUri: 'file:///active.ts' }
+
+  await expect(handleDiagnosticsChange(state, 'file:///inactive.ts')).resolves.toBe(state)
+  expect(mockRpc.invocations).toEqual([])
 })


### PR DESCRIPTION
Refreshes the open Problems view when diagnostics for the active editor change, while ignoring updates for inactive files.