### PR TITLE
feature: add 120 problems view e2e tests

### DIFF
--- a/packages/e2e/src/problems.active-uri-authority.ts
+++ b/packages/e2e/src/problems.active-uri-authority.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-authority'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs://remote/workspace/source.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-custom-scheme.ts
+++ b/packages/e2e/src/problems.active-uri-custom-scheme.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-custom-scheme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'custom-scheme:///workspace/source.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-dollar.ts
+++ b/packages/e2e/src/problems.active-uri-dollar.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-dollar'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/$generated.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-emoji.ts
+++ b/packages/e2e/src/problems.active-uri-emoji.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-emoji'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/🔥.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-encoded-brackets.ts
+++ b/packages/e2e/src/problems.active-uri-encoded-brackets.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-encoded-brackets'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  // cspell:disable-next-line
+  const uri = 'memfs:///workspace/file-%5Btest%5D.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-encoded-hash.ts
+++ b/packages/e2e/src/problems.active-uri-encoded-hash.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-encoded-hash'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/file-%23-name.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-encoded-space.ts
+++ b/packages/e2e/src/problems.active-uri-encoded-space.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-encoded-space'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/folder%20with%20spaces/main.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-encoded-unicode.ts
+++ b/packages/e2e/src/problems.active-uri-encoded-unicode.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-encoded-unicode'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/%E6%96%87%E4%BB%B6.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-file-scheme.ts
+++ b/packages/e2e/src/problems.active-uri-file-scheme.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-file-scheme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'file:///tmp/project/main.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-hidden-file.ts
+++ b/packages/e2e/src/problems.active-uri-hidden-file.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-hidden-file'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/.config'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-http-scheme.ts
+++ b/packages/e2e/src/problems.active-uri-http-scheme.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-http-scheme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'http://localhost/source.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-https-scheme.ts
+++ b/packages/e2e/src/problems.active-uri-https-scheme.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-https-scheme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'https://example.com/source.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-localhost-authority.ts
+++ b/packages/e2e/src/problems.active-uri-localhost-authority.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-localhost-authority'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs://localhost/workspace/source.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-long-path.ts
+++ b/packages/e2e/src/problems.active-uri-long-path.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-long-path'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri =
+    'memfs:///workspace/nested/nested/nested/nested/nested/nested/nested/nested/nested/nested/nested/nested/nested/nested/nested/nested/main.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-memfs-basic.ts
+++ b/packages/e2e/src/problems.active-uri-memfs-basic.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-memfs-basic'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/main.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-memfs-nested.ts
+++ b/packages/e2e/src/problems.active-uri-memfs-nested.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-memfs-nested'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/src/components/main.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-multiple-dots.ts
+++ b/packages/e2e/src/problems.active-uri-multiple-dots.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-multiple-dots'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/archive.test.spec.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-plus.ts
+++ b/packages/e2e/src/problems.active-uri-plus.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-plus'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/file+name.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-semicolon.ts
+++ b/packages/e2e/src/problems.active-uri-semicolon.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-semicolon'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/file;variant.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-sequence-case-sensitive.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-case-sensitive.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-case-sensitive'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/main.ts', 'memfs:///workspace/Main.ts', 'memfs:///workspace/MAIN.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-encoded-files.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-encoded-files.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-encoded-files'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/a%20b.ts', 'memfs:///workspace/c%23d.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-extensions.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-extensions.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-extensions'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/main.js', 'memfs:///workspace/main.ts', 'memfs:///workspace/main.py']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-many-changes.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-many-changes.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-many-changes'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/1.ts', 'memfs:///workspace/2.ts', 'memfs:///workspace/3.ts', 'memfs:///workspace/4.ts', 'memfs:///workspace/5.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-nested-folders.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-nested-folders.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-nested-folders'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/a/one.ts', 'memfs:///workspace/b/two.ts', 'memfs:///workspace/c/three.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-return-to-first.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-return-to-first.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-return-to-first'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/first.ts', 'memfs:///workspace/second.ts', 'memfs:///workspace/first.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-same-uri.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-same-uri.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-same-uri'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/same.ts', 'memfs:///workspace/same.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-three-files.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-three-files.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-three-files'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/one.ts', 'memfs:///workspace/two.ts', 'memfs:///workspace/three.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-two-files.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-two-files.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-two-files'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/one.ts', 'memfs:///workspace/two.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-sequence-unicode-files.ts
+++ b/packages/e2e/src/problems.active-uri-sequence-unicode-files.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-sequence-unicode-files'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const problemsView = Locator('.Viewlet.Problems')
+  const uris = ['memfs:///workspace/一.ts', 'memfs:///workspace/二.ts', 'memfs:///workspace/三.ts']
+
+  for (const uri of uris) {
+    await Command.execute('Problems.handleActiveEditorChange', uri)
+    await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  }
+}

--- a/packages/e2e/src/problems.active-uri-space.ts
+++ b/packages/e2e/src/problems.active-uri-space.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-space'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/folder with spaces/main.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-trailing-slash.ts
+++ b/packages/e2e/src/problems.active-uri-trailing-slash.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-trailing-slash'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/folder/'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-unicode.ts
+++ b/packages/e2e/src/problems.active-uri-unicode.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-unicode'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/文件.ts'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-untitled-scheme.ts
+++ b/packages/e2e/src/problems.active-uri-untitled-scheme.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-untitled-scheme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'untitled:Untitled-1'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-uppercase-extension.ts
+++ b/packages/e2e/src/problems.active-uri-uppercase-extension.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-uppercase-extension'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'memfs:///workspace/MAIN.TS'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.active-uri-userdata-scheme.ts
+++ b/packages/e2e/src/problems.active-uri-userdata-scheme.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.active-uri-userdata-scheme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel }) => {
+  await Panel.open('Problems')
+  const uri = 'vscode-userdata:/User/settings.json'
+
+  await Command.execute('Problems.handleActiveEditorChange', uri)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toHaveAttribute('data-active-uri', uri)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.empty-state-sequence-all-actions.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-all-actions.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-all-actions'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['blur', 'click', 'focus', 'icon-theme', 'table', 'list']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-blur-icon-theme.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-blur-icon-theme.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-blur-icon-theme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['blur', 'icon-theme']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-click-blur.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-click-blur.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-click-blur'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['click', 'blur']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-click-table-list.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-click-table-list.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-click-table-list'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['click', 'table', 'list']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-focus-blur.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-focus-blur.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-focus-blur'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['focus', 'blur']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-focus-table-list.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-focus-table-list.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-focus-table-list'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['focus', 'table', 'list']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-icon-theme-blur.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-icon-theme-blur.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-icon-theme-blur'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['icon-theme', 'blur']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-list-icon-theme.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-list-icon-theme.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-list-icon-theme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['list', 'icon-theme']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-reverse-actions.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-reverse-actions.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-reverse-actions'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['list', 'table', 'icon-theme', 'focus', 'click', 'blur']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.empty-state-sequence-table-icon-theme.ts
+++ b/packages/e2e/src/problems.empty-state-sequence-table-icon-theme.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.empty-state-sequence-table-icon-theme'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const actions = ['table', 'icon-theme']
+
+  const runAction = async (action: string): Promise<void> => {
+    switch (action) {
+      case 'blur':
+        await Command.execute('Problems.handleBlur')
+        break
+      case 'click':
+        await Problems.handleClickAt(10, 10)
+        break
+      case 'focus':
+        await Problems.focusIndex(-1)
+        break
+      case 'icon-theme':
+        await Problems.handleIconThemeChange()
+        break
+      case 'list':
+        await Problems.viewAsList()
+        break
+      default:
+        await Problems.viewAsTable()
+        break
+    }
+  }
+
+  for (const action of actions) {
+    await runAction(action)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.filter-menu-value-emoji.ts
+++ b/packages/e2e/src/problems.filter-menu-value-emoji.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-emoji'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('🚨')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('🚨')
+}

--- a/packages/e2e/src/problems.filter-menu-value-leading-space.ts
+++ b/packages/e2e/src/problems.filter-menu-value-leading-space.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-leading-space'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput(' leading')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue(' leading')
+}

--- a/packages/e2e/src/problems.filter-menu-value-long-value.ts
+++ b/packages/e2e/src/problems.filter-menu-value-long-value.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-long-value'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput(
+    'filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-',
+  )
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue(
+    'filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-filter-menu-',
+  )
+}

--- a/packages/e2e/src/problems.filter-menu-value-numeric.ts
+++ b/packages/e2e/src/problems.filter-menu-value-numeric.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-numeric'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('404')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('404')
+}

--- a/packages/e2e/src/problems.filter-menu-value-path.ts
+++ b/packages/e2e/src/problems.filter-menu-value-path.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-path'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('src/main.ts')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('src/main.ts')
+}

--- a/packages/e2e/src/problems.filter-menu-value-punctuation.ts
+++ b/packages/e2e/src/problems.filter-menu-value-punctuation.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-punctuation'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('[]{}()')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('[]{}()')
+}

--- a/packages/e2e/src/problems.filter-menu-value-spaces.ts
+++ b/packages/e2e/src/problems.filter-menu-value-spaces.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-spaces'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('two words')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('two words')
+}

--- a/packages/e2e/src/problems.filter-menu-value-trailing-space.ts
+++ b/packages/e2e/src/problems.filter-menu-value-trailing-space.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-trailing-space'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('trailing ')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('trailing ')
+}

--- a/packages/e2e/src/problems.filter-menu-value-unicode.ts
+++ b/packages/e2e/src/problems.filter-menu-value-unicode.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-unicode'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('文件')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('文件')
+}

--- a/packages/e2e/src/problems.filter-menu-value-uppercase.ts
+++ b/packages/e2e/src/problems.filter-menu-value-uppercase.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-menu-value-uppercase'
+
+export const test: Test = async ({ Command, expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  await Problems.handleFilterInput('ERROR')
+
+  await Command.execute('Problems.handleClickMoreFilters', 0, 0)
+
+  const menu = Locator('.Menu')
+  const menuItems = menu.locator('.MenuItem')
+  const input = Locator('.Panel .InputBox')
+  await expect(menuItems).toHaveCount(3)
+  await expect(menuItems.nth(0)).toHaveText('Show Errors')
+  await expect(menuItems.nth(1)).toHaveText('Show Warnings')
+  await expect(menuItems.nth(2)).toHaveText('Show Infos')
+  await expect(input).toHaveValue('ERROR')
+}

--- a/packages/e2e/src/problems.filter-sequence-alternating.ts
+++ b/packages/e2e/src/problems.filter-sequence-alternating.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-alternating'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['error', 'warning', 'error', 'warning']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-case-changes.ts
+++ b/packages/e2e/src/problems.filter-sequence-case-changes.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-case-changes'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['error', 'Error', 'ERROR']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-clear.ts
+++ b/packages/e2e/src/problems.filter-sequence-clear.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-clear'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['missing', '']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-emoji.ts
+++ b/packages/e2e/src/problems.filter-sequence-emoji.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-emoji'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['🙂', '🙂🙃', '🚨']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-empty-then-value.ts
+++ b/packages/e2e/src/problems.filter-sequence-empty-then-value.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-empty-then-value'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['', 'info']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-grow.ts
+++ b/packages/e2e/src/problems.filter-sequence-grow.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-grow'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['e', 'er', 'err', 'error']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-numeric.ts
+++ b/packages/e2e/src/problems.filter-sequence-numeric.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-numeric'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['1', '12', '123', '0']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-path.ts
+++ b/packages/e2e/src/problems.filter-sequence-path.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-path'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['src', 'src/', 'src/main', 'src/main.ts']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-prefix-suffix.ts
+++ b/packages/e2e/src/problems.filter-sequence-prefix-suffix.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-prefix-suffix'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['error', 'pre-error', 'pre-error-post']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-punctuation.ts
+++ b/packages/e2e/src/problems.filter-sequence-punctuation.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-punctuation'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['.', '.*', '[.*]']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-rapid-five.ts
+++ b/packages/e2e/src/problems.filter-sequence-rapid-five.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-rapid-five'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['a', 'b', 'c', 'd', 'e']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-repeated-value.ts
+++ b/packages/e2e/src/problems.filter-sequence-repeated-value.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-repeated-value'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['same', 'same', 'same']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-shrink.ts
+++ b/packages/e2e/src/problems.filter-sequence-shrink.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-shrink'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['warning', 'warn', 'war', 'w']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-spaces.ts
+++ b/packages/e2e/src/problems.filter-sequence-spaces.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-spaces'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = [' leading', 'middle space', 'trailing ']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-sequence-unicode.ts
+++ b/packages/e2e/src/problems.filter-sequence-unicode.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-sequence-unicode'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const input = Locator('.Panel .InputBox')
+  const values = ['文', '文件', '文件错误']
+
+  for (const value of values) {
+    await Problems.handleFilterInput(value)
+    await expect(input).toHaveValue(value)
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-accented.ts
+++ b/packages/e2e/src/problems.filter-value-accented.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-accented'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'résumé naïve'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-ampersand.ts
+++ b/packages/e2e/src/problems.filter-value-ampersand.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-ampersand'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'error&warning'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-angle-brackets.ts
+++ b/packages/e2e/src/problems.filter-value-angle-brackets.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-angle-brackets'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '<expected>'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-arabic.ts
+++ b/packages/e2e/src/problems.filter-value-arabic.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-arabic'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  // cspell:disable-next-line
+  const value = 'خطأ في الملف'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-backslash.ts
+++ b/packages/e2e/src/problems.filter-value-backslash.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-backslash'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'src\\main.ts'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-backtick.ts
+++ b/packages/e2e/src/problems.filter-value-backtick.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-backtick'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '`template`'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-braces.ts
+++ b/packages/e2e/src/problems.filter-value-braces.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-braces'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '{expected}'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-brackets.ts
+++ b/packages/e2e/src/problems.filter-value-brackets.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-brackets'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '[expected]'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-cjk.ts
+++ b/packages/e2e/src/problems.filter-value-cjk.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-cjk'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '文件错误'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-colon.ts
+++ b/packages/e2e/src/problems.filter-value-colon.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-colon'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'source:message'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-combining-mark.ts
+++ b/packages/e2e/src/problems.filter-value-combining-mark.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-combining-mark'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'Café'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-comma.ts
+++ b/packages/e2e/src/problems.filter-value-comma.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-comma'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'source,message'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-devanagari.ts
+++ b/packages/e2e/src/problems.filter-value-devanagari.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-devanagari'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  // cspell:disable-next-line
+  const value = 'फ़ाइल त्रुटि'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-digits.ts
+++ b/packages/e2e/src/problems.filter-value-digits.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-digits'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '1234567890'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-dotted-path.ts
+++ b/packages/e2e/src/problems.filter-value-dotted-path.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-dotted-path'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'src.components.button.ts'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-double-quote.ts
+++ b/packages/e2e/src/problems.filter-value-double-quote.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-double-quote'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '"quoted message"'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-emoji.ts
+++ b/packages/e2e/src/problems.filter-value-emoji.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-emoji'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '🔥 compile 💥'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-equals.ts
+++ b/packages/e2e/src/problems.filter-value-equals.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-equals'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'code=42'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-forward-slash.ts
+++ b/packages/e2e/src/problems.filter-value-forward-slash.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-forward-slash'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'src/main.ts'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-hash.ts
+++ b/packages/e2e/src/problems.filter-value-hash.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-hash'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '#diagnostic'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-hyphen.ts
+++ b/packages/e2e/src/problems.filter-value-hyphen.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-hyphen'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'missing-item'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-leading-zero.ts
+++ b/packages/e2e/src/problems.filter-value-leading-zero.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-leading-zero'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '00042'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-long-value.ts
+++ b/packages/e2e/src/problems.filter-value-long-value.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-long-value'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value =
+    'diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-diagnostic-'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-mixed-case.ts
+++ b/packages/e2e/src/problems.filter-value-mixed-case.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-mixed-case'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'ErRoR'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-non-breaking-space.ts
+++ b/packages/e2e/src/problems.filter-value-non-breaking-space.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-non-breaking-space'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'error message'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-percent.ts
+++ b/packages/e2e/src/problems.filter-value-percent.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-percent'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = '100%'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-semicolon.ts
+++ b/packages/e2e/src/problems.filter-value-semicolon.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-semicolon'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'source;message'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-single-quote.ts
+++ b/packages/e2e/src/problems.filter-value-single-quote.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-single-quote'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = "can't compile"
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-underscore.ts
+++ b/packages/e2e/src/problems.filter-value-underscore.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-underscore'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'missing_item'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.filter-value-uppercase.ts
+++ b/packages/e2e/src/problems.filter-value-uppercase.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.filter-value-uppercase'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const value = 'ERROR'
+
+  await Problems.handleFilterInput(value)
+
+  const input = Locator('.Panel .InputBox')
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveValue(value)
+  await expect(problemsView).toBeVisible()
+}

--- a/packages/e2e/src/problems.focus-boundary-click-negative.ts
+++ b/packages/e2e/src/problems.focus-boundary-click-negative.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-click-negative'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.handleClickAt(-1, -1)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-click-origin.ts
+++ b/packages/e2e/src/problems.focus-boundary-click-origin.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-click-origin'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.handleClickAt(0, 0)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-click-outside.ts
+++ b/packages/e2e/src/problems.focus-boundary-click-outside.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-click-outside'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.handleClickAt(9999, 9999)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-focus-default.ts
+++ b/packages/e2e/src/problems.focus-boundary-focus-default.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-focus-default'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.focusIndex(-2)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-focus-large.ts
+++ b/packages/e2e/src/problems.focus-boundary-focus-large.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-focus-large'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.focusIndex(999_999)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-focus-negative-hundred.ts
+++ b/packages/e2e/src/problems.focus-boundary-focus-negative-hundred.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-focus-negative-hundred'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.focusIndex(-100)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-focus-negative-thousand.ts
+++ b/packages/e2e/src/problems.focus-boundary-focus-negative-thousand.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-focus-negative-thousand'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.focusIndex(-1000)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-focus-none.ts
+++ b/packages/e2e/src/problems.focus-boundary-focus-none.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-focus-none'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.focusIndex(-1)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-focus-one.ts
+++ b/packages/e2e/src/problems.focus-boundary-focus-one.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-focus-one'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.focusIndex(1)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.focus-boundary-focus-zero.ts
+++ b/packages/e2e/src/problems.focus-boundary-focus-zero.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.focus-boundary-focus-zero'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+
+  await Problems.focusIndex(0)
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-four-toggles.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-four-toggles.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-four-toggles'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['table', 'list', 'table', 'list']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-list-once.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-list-once.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-list-once'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['list']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-list-table-list.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-list-table-list.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-list-table-list'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['list', 'table', 'list']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-list-three-times.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-list-three-times.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-list-three-times'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['list', 'list', 'list']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-list-twice.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-list-twice.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-list-twice'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['list', 'list']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-mixed-five.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-mixed-five.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-mixed-five'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['table', 'list', 'list', 'table', 'list']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-mixed-six.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-mixed-six.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-mixed-six'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['list', 'table', 'table', 'list', 'table', 'list']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-table-list-table.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-table-list-table.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-table-list-table'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['table', 'list', 'table']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-table-three-times.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-table-three-times.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-table-three-times'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['table', 'table', 'table']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/e2e/src/problems.view-mode-sequence-table-twice.ts
+++ b/packages/e2e/src/problems.view-mode-sequence-table-twice.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.view-mode-sequence-table-twice'
+
+export const test: Test = async ({ expect, Locator, Panel, Problems }) => {
+  await Panel.open('Problems')
+  const viewModes = ['table', 'table']
+
+  for (const viewMode of viewModes) {
+    if (viewMode === 'list') {
+      await Problems.viewAsList()
+    } else {
+      await Problems.viewAsTable()
+    }
+  }
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}


### PR DESCRIPTION
Adds 120 standalone e2e scenarios covering filter values and transitions, active URI changes, view-mode transitions, focus and click boundaries, empty-state command sequences, and filter-menu state.