### PR TITLE
feature: move getListItemType

### DIFF
--- a/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
+++ b/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
@@ -1,17 +1,8 @@
 import type { FilteredProblem } from '../FilteredProblem/FilteredProblem.ts'
+import { getListItemType } from '../GetListItemType/GetListItemType.ts'
 import type { Problem } from '../Problem/Problem.ts'
 import { matchesFilterValue } from '../MatchesFilterValue/MatchesFilterValue.ts'
 import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType.ts'
-
-const getListItemType = (listItemType: number, isCollapsed: boolean): number => {
-  if (listItemType === ProblemListItemType.Item) {
-    return ProblemListItemType.Item
-  }
-  if (isCollapsed) {
-    return ProblemListItemType.Collapsed
-  }
-  return ProblemListItemType.Expanded
-}
 
 export const filterProblems = (problems: readonly Problem[], collapsedUris: readonly string[], filterValue: string): readonly FilteredProblem[] => {
   const filterValueLower = filterValue.toLowerCase()

--- a/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
+++ b/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
@@ -1,6 +1,6 @@
 import type { FilteredProblem } from '../FilteredProblem/FilteredProblem.ts'
-import { getListItemType } from '../GetListItemType/GetListItemType.ts'
 import type { Problem } from '../Problem/Problem.ts'
+import { getListItemType } from '../GetListItemType/GetListItemType.ts'
 import { matchesFilterValue } from '../MatchesFilterValue/MatchesFilterValue.ts'
 import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType.ts'
 

--- a/packages/problems-view/src/parts/GetListItemType/GetListItemType.ts
+++ b/packages/problems-view/src/parts/GetListItemType/GetListItemType.ts
@@ -1,0 +1,11 @@
+import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType.ts'
+
+export const getListItemType = (listItemType: number, isCollapsed: boolean): number => {
+  if (listItemType === ProblemListItemType.Item) {
+    return ProblemListItemType.Item
+  }
+  if (isCollapsed) {
+    return ProblemListItemType.Collapsed
+  }
+  return ProblemListItemType.Expanded
+}


### PR DESCRIPTION
Move getListItemType out of FilterProblems into its own module, following the Problems View parts layout.