### PR TITLE
fix: bound collapsed problems state

### DIFF
--- a/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
+++ b/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
@@ -6,6 +6,7 @@ import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType
 
 export const filterProblems = (problems: readonly Problem[], collapsedUris: readonly string[], filterValue: string): readonly FilteredProblem[] => {
   const filterValueLower = filterValue.toLowerCase()
+  const collapsedUriSet = new Set(collapsedUris)
   const filtered = []
   for (const problem of problems) {
     const uriMatchIndex = matchesFilterValue(problem.uri, filterValueLower)
@@ -14,7 +15,7 @@ export const filterProblems = (problems: readonly Problem[], collapsedUris: read
     if (uriMatchIndex === -1 && sourceMatchIndex === -1 && messageMatchIndex === -1) {
       continue
     }
-    const isCollapsed = collapsedUris.includes(problem.uri)
+    const isCollapsed = collapsedUriSet.has(problem.uri)
     if (isCollapsed && problem.listItemType === ProblemListItemType.Item) {
       continue
     }

--- a/packages/problems-view/src/parts/HandleArrowLeft/HandleArrowLeft.ts
+++ b/packages/problems-view/src/parts/HandleArrowLeft/HandleArrowLeft.ts
@@ -9,7 +9,7 @@ const getArrowLeftNewFocusedIndex = (problems: readonly Problem[], collapsedUris
     if (problem.listItemType !== ProblemListItemType.Item) {
       return {
         index: i,
-        newCollapsedUris: [...collapsedUris, problem.uri],
+        newCollapsedUris: collapsedUris.includes(problem.uri) ? collapsedUris : [...collapsedUris, problem.uri],
       }
     }
   }

--- a/packages/problems-view/src/parts/HandleArrowRight/HandleArrowRight.ts
+++ b/packages/problems-view/src/parts/HandleArrowRight/HandleArrowRight.ts
@@ -1,6 +1,5 @@
 import type { Problem } from '../Problem/Problem.ts'
 import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
-import * as Arrays from '../Arrays/Arrays.ts'
 
 interface NewFocusedIndexResult {
   readonly index: number
@@ -13,7 +12,7 @@ const getArrowRightNewFocusedIndex = (
   focusedIndex: number,
 ): NewFocusedIndexResult => {
   const problem = problems[focusedIndex]
-  const newCollapsedUris = Arrays.removeElement(collapsedUris, problem.uri)
+  const newCollapsedUris = collapsedUris.includes(problem.uri) ? collapsedUris.filter((uri) => uri !== problem.uri) : collapsedUris
   return {
     index: focusedIndex,
     newCollapsedUris,

--- a/packages/problems-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/problems-view/src/parts/LoadContent/LoadContent.ts
@@ -25,7 +25,7 @@ const isString = (value: unknown): boolean => {
 
 const getSavedCollapsedUris = (savedState: any): readonly string[] => {
   if (savedState && savedState.collapsedUris && Array.isArray(savedState.collapsedUris) && savedState.collapsedUris.every(isString)) {
-    return savedState.collapsedUris
+    return [...new Set(savedState.collapsedUris)]
   }
   return []
 }

--- a/packages/problems-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/problems-view/src/parts/LoadContent/LoadContent.ts
@@ -19,13 +19,14 @@ const getSavedFilterValue = (savedState: any): string => {
   return ''
 }
 
-const isString = (value: unknown): boolean => {
+const isString = (value: unknown): value is string => {
   return typeof value === 'string'
 }
 
 const getSavedCollapsedUris = (savedState: any): readonly string[] => {
-  if (savedState && savedState.collapsedUris && Array.isArray(savedState.collapsedUris) && savedState.collapsedUris.every(isString)) {
-    return [...new Set(savedState.collapsedUris)]
+  const collapsedUris: unknown = savedState?.collapsedUris
+  if (Array.isArray(collapsedUris) && collapsedUris.every(isString)) {
+    return [...new Set(collapsedUris)]
   }
   return []
 }

--- a/packages/problems-view/test/HandleArrowLeft.test.ts
+++ b/packages/problems-view/test/HandleArrowLeft.test.ts
@@ -56,3 +56,14 @@ test('handleArrowLeft collapses Collapsed type as well', () => {
   expect(newState.focusedIndex).toBe(1)
   expect(newState.collapsedUris).toContain('b')
 })
+
+test('handleArrowLeft does not add duplicate collapsed uris', () => {
+  const problems: Problem[] = [{ ...defaultProblem, listItemType: ProblemListItemType.Expanded, uri: 'a' }]
+  let state: ProblemsState = { ...CreateDefaultState.createDefaultState(), collapsedUris: [], focusedIndex: 0, problems }
+
+  state = HandleArrowLeft.handleArrowLeft(state)
+  state = HandleArrowLeft.handleArrowLeft(state)
+  state = HandleArrowLeft.handleArrowLeft(state)
+
+  expect(state.collapsedUris).toEqual(['a'])
+})

--- a/packages/problems-view/test/HandleArrowRight.test.ts
+++ b/packages/problems-view/test/HandleArrowRight.test.ts
@@ -57,3 +57,12 @@ test('handleArrowRight removes uri from collapsedUris if present', () => {
   expect(newState.focusedIndex).toBe(1)
   expect(newState.collapsedUris).toEqual(['a', 'c'])
 })
+
+test('handleArrowRight removes duplicate collapsed uris from legacy state', () => {
+  const problems: Problem[] = [{ ...defaultProblem, listItemType: ProblemListItemType.Collapsed, uri: 'b' }]
+  const state: ProblemsState = { ...createDefaultState(), collapsedUris: ['b', 'a', 'b', 'b'], focusedIndex: 0, problems }
+
+  const newState = handleArrowRight(state)
+
+  expect(newState.collapsedUris).toEqual(['a'])
+})

--- a/packages/problems-view/test/LoadContent.test.ts
+++ b/packages/problems-view/test/LoadContent.test.ts
@@ -113,6 +113,21 @@ test('loadContent with savedState containing collapsedUris', async () => {
   expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
+test('loadContent removes duplicate collapsed uris from saved state', async () => {
+  using mockRpc = registerEditorWorker({
+    'Editor.getProblems': () => [],
+  })
+  const state: ProblemsState = createDefaultState()
+  const savedState = {
+    collapsedUris: ['file:///test1.ts', 'file:///test2.ts', 'file:///test1.ts'],
+  }
+
+  const result = await loadContent(state, savedState)
+
+  expect(result.collapsedUris).toEqual(['file:///test1.ts', 'file:///test2.ts'])
+  expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
+})
+
 test('loadContent with savedState containing all properties', async () => {
   registerEditorWorker({
     'Editor.getProblems': () => [],


### PR DESCRIPTION
Prevent repeated collapse actions from appending duplicate URIs. Normalize legacy saved state and use bounded collapsed-URI lookups while filtering.