### PR TITLE
fix: repair dev build watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "node packages/build/src/build.ts",
     "build:static": "node packages/build/src/build-static.ts",
-    "build:watch": "./packages/build/node_modules/.bin/esbuild --format=esm --bundle --external:node:buffer --external:electron --external:ws --external:node:worker_threads --watch packages/problems-view/src/problemsViewWorkerMain.ts --outfile=.tmp/dist/dist/problemsViewWorkerMain.js",
+    "build:watch": "npm exec --workspace=packages/build -- esbuild --format=esm --bundle --external:node:buffer --external:electron --external:ws --external:node:worker_threads --watch ../problems-view/src/problemsViewWorkerMain.ts --outfile=../../.tmp/dist/dist/problemsViewWorkerMain.js",
     "dev": "node packages/build/src/dev.ts",
     "e2e": "cd packages/e2e && npm run e2e",
     "format": "prettier --write .",


### PR DESCRIPTION
Fix the dev watcher to resolve esbuild through the build workspace and use paths relative to that workspace.