### PR TITLE
fix: enable one problem e2e test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2605,6 +2605,29 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/api": {
+      "version": "8.79.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.79.0.tgz",
+      "integrity": "sha512-5HaqvRO9zoUbRK2fWbmvsCORhS6Af+Criu2ZvX4D2KA7HGCX9C6j8VCSQ1du/QKsNOaahUYkYEsxipYfno4Z8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.4.0",
+        "@lvce-editor/rpc-registry": "^9.24.0",
+        "@lvce-editor/virtual-dom-worker": "^10.0.0"
+      }
+    },
+    "node_modules/@lvce-editor/api/node_modules/@lvce-editor/virtual-dom-worker": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-10.2.0.tgz",
+      "integrity": "sha512-URtDWcAFadP7SLOqfepRxomJmNRQDmON8GFKRfsA1dOgcqBnoBR4G5xwo6oDeZvP4pnRAzHR3QB3b8I6nASU+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/constants": "^5.14.0"
+      }
+    },
     "node_modules/@lvce-editor/assert": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
@@ -14434,6 +14457,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
+        "@lvce-editor/api": "^8.79.0",
         "@lvce-editor/test-with-playwright": "^22.14.0"
       }
     },

--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -2,6 +2,7 @@ import { execa } from 'execa'
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { bundleJs } from './bundleJs.ts'
+import { buildE2eExtensions } from './buildE2eExtensions.ts'
 import { root } from './root.ts'
 
 const dist = join(root, '.tmp', 'dist')
@@ -53,6 +54,7 @@ await rm(dist, { recursive: true, force: true })
 await mkdir(dist, { recursive: true })
 
 await bundleJs()
+await buildE2eExtensions()
 
 const version = await getVersion()
 

--- a/packages/build/src/buildE2eExtensions.ts
+++ b/packages/build/src/buildE2eExtensions.ts
@@ -1,0 +1,20 @@
+import { build } from 'esbuild'
+import { join } from 'node:path'
+import { root } from './root.ts'
+
+const buildE2eExtension = async (extensionName: string): Promise<void> => {
+  const extensionPath = join(root, 'packages', 'e2e', 'fixtures', extensionName)
+  await build({
+    bundle: true,
+    entryPoints: [join(extensionPath, 'main.js')],
+    external: ['electron', 'node:*'],
+    format: 'esm',
+    outfile: join(extensionPath, 'dist', 'main.js'),
+    platform: 'browser',
+    target: 'esnext',
+  })
+}
+
+export const buildE2eExtensions = async (): Promise<void> => {
+  await buildE2eExtension('problems.one-problem')
+}

--- a/packages/e2e/fixtures/problems.one-problem/extension.json
+++ b/packages/e2e/fixtures/problems.one-problem/extension.json
@@ -1,5 +1,12 @@
 {
-  "browser": "main.js",
+  "browser": "dist/main.js",
+  "isolated": true,
+  "diagnosticProviders": [
+    {
+      "id": "xyz-diagnostics",
+      "languageId": "xyz"
+    }
+  ],
   "languages": [
     {
       "id": "xyz",

--- a/packages/e2e/fixtures/problems.one-problem/main.js
+++ b/packages/e2e/fixtures/problems.one-problem/main.js
@@ -1,4 +1,7 @@
+import { activate as activateExtensionApi, registerDiagnosticProvider } from '@lvce-editor/api'
+
 const diagnosticProvider = {
+  id: 'xyz-diagnostics',
   languageId: 'xyz',
   provideDiagnostics(textDocument, offset) {
     return [
@@ -6,13 +9,15 @@ const diagnosticProvider = {
         uri: textDocument.uri,
         rowIndex: 0,
         columnIndex: 0,
+        endRowIndex: 0,
+        endColumnIndex: 0,
         message: 'error 1',
         source: 'xyz',
+        type: 'error',
       },
     ]
   },
 }
 
-export const activate = () => {
-  vscode.registerDiagnosticProvider(diagnosticProvider)
-}
+await activateExtensionApi()
+registerDiagnosticProvider(diagnosticProvider)

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc"
   },
   "devDependencies": {
+    "@lvce-editor/api": "^8.79.0",
     "@lvce-editor/test-with-playwright": "^22.14.0"
   }
 }

--- a/packages/e2e/src/problems.one-problem.ts
+++ b/packages/e2e/src/problems.one-problem.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.one-problem'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Extension, FileSystem, Locator, Main, Panel, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()


### PR DESCRIPTION
Migrates the one-problem diagnostic fixture to the isolated extension API and explicitly selects the Problems view before asserting its rendered diagnostics.