### PR TITLE
fix: preserve problem message for source filters

### DIFF
--- a/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
@@ -107,7 +107,7 @@ export const getProblemVirtualDom = (problem: VisibleProblem): readonly VirtualD
     GetProblemsIconVirtualDom.getProblemsIconVirtualDom(type),
     label,
   ]
-  if (filterValueLength) {
+  if (filterValueLength && messageMatchIndex >= 0) {
     const before = message.slice(0, messageMatchIndex)
     const middle = message.slice(messageMatchIndex, messageMatchIndex + filterValueLength)
     const after = message.slice(messageMatchIndex + filterValueLength)

--- a/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
@@ -315,3 +315,31 @@ test('getProblemVirtualDom returns correct dom for Item with filter highlight', 
   ]
   expect(dom).toEqual(expectedDom)
 })
+
+test('getProblemVirtualDom leaves message unchanged when filter matches source', () => {
+  const problem: VisibleProblem = {
+    ...baseProblem,
+    filterValueLength: 10,
+    icon: 'icon-ts',
+    isActive: false,
+    isCollapsed: false,
+    isEven: false,
+    listItemType: ProblemListItemType.Item,
+    messageMatchIndex: -1,
+    sourceMatchIndex: 0,
+  }
+  const dom = getProblemVirtualDom(problem)
+  const labelIndex = dom.findIndex((node) => node.className === ClassNames.ProblemLabel)
+  expect(dom.slice(labelIndex, labelIndex + 2)).toEqual([
+    {
+      childCount: 1,
+      className: ClassNames.ProblemLabel,
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      text: 'Syntax error',
+      type: VirtualDomElements.Text,
+    },
+  ])
+})


### PR DESCRIPTION
Fixes Problems source filters rendering a duplicated diagnostic message by only applying message highlighting when the message itself matched. Adds focused renderer regression coverage.