### PR TITLE
fix: restore problems filter input value

### DIFF
--- a/packages/problems-view/src/parts/GetInputBoxVirtualDom/GetInputBoxVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetInputBoxVirtualDom/GetInputBoxVirtualDom.ts
@@ -2,7 +2,7 @@ import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 
-export const getInputBoxVirtualDom = (name: string, onInput: string | number, placeholder: string): VirtualDomNode => {
+export const getInputBoxVirtualDom = (name: string, onInput: string | number, placeholder: string, value?: string): VirtualDomNode => {
   return {
     ariaLabel: placeholder,
     autocapitalize: 'off',
@@ -14,5 +14,6 @@ export const getInputBoxVirtualDom = (name: string, onInput: string | number, pl
     placeholder,
     spellcheck: false,
     type: VirtualDomElements.Input,
+    ...(value && { value }),
   }
 }

--- a/packages/problems-view/src/parts/GetProblemsFilterVirtualDom/GetProblemsFilterVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsFilterVirtualDom/GetProblemsFilterVirtualDom.ts
@@ -26,7 +26,7 @@ export const getProblemsFilterVirtualDom = (action: ViewletAction): readonly Vir
       className: ClassNames.Filter,
       type: VirtualDomElements.Div,
     },
-    getInputBoxVirtualDom(InputName.Filter, action.command, action.placeholder || ''),
+    getInputBoxVirtualDom(InputName.Filter, action.command, action.placeholder || '', action.value),
     ...getFilterBadgeDom(action.badgeText),
     ...GetActionButtonVirtualDom.getActionButtonVirtualDom({
       command: 'more filters',

--- a/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsVirtualDom/GetProblemsVirtualDom.ts
@@ -42,7 +42,7 @@ export const getProblemsVirtualDom = (
         id: DomId.Filter,
         placeholder: ProblemStrings.filter(),
         type: ActionType.ProblemsFilter,
-        value: '',
+        value: filterValue,
       })
     : []
 

--- a/packages/problems-view/test/GetProblemsFilterVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsFilterVirtualDom.test.ts
@@ -76,6 +76,7 @@ test('getProblemsFilterVirtualDom returns correct dom structure with badge', () 
       placeholder: 'Filter problems',
       spellcheck: false,
       type: VirtualDomElements.Input,
+      value: 'test',
     },
     {
       childCount: 1,

--- a/packages/problems-view/test/GetProblemsVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsVirtualDom.test.ts
@@ -3,10 +3,11 @@ import { getProblemsVirtualDom } from '../src/parts/GetProblemsVirtualDom/GetPro
 import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
 
 test('getProblemsVirtualDom includes the filter and items as root children at small widths', () => {
-  const dom = getProblemsVirtualDom('file:///active.ts', ProblemsViewMode.List, [], '', true, 'No problems')
+  const dom = getProblemsVirtualDom('file:///active.ts', ProblemsViewMode.List, [], 'restored filter', true, 'No problems')
 
   expect(dom[0].childCount).toBe(2)
   expect(dom[0]['data-activeUri']).toBe('file:///active.ts')
+  expect(dom[2].value).toBe('restored filter')
 })
 
 test('getProblemsVirtualDom includes only the items as a root child at large widths', () => {


### PR DESCRIPTION
## Summary

- hydrate non-empty scripted filter values in the Problems filter input
- preserve user-owned typing by omitting empty value properties
- restore the compact-layout filter from the same saved value

## Testing

- npm test -- --runInBand (77 suites, 297 passed, 1 todo)
- npm run type-check
- npm run lint