### PR TITLE
fix: show cross-file problems

### DIFF
--- a/packages/problems-view/src/parts/GetProblems/GetProblems.ts
+++ b/packages/problems-view/src/parts/GetProblems/GetProblems.ts
@@ -1,6 +1,30 @@
+import type { Diagnostic } from '../Diagnostic/Diagnostic.ts'
 import type { ProblemsResult } from '../ProblemsResult/ProblemsResult.ts'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import { toProblems } from '../ToProblems/ToProblems.ts'
+
+const getDiagnosticKey = (diagnostic: Diagnostic): string =>
+  JSON.stringify([
+    diagnostic.uri,
+    diagnostic.rowIndex,
+    diagnostic.columnIndex,
+    diagnostic.message,
+    diagnostic.source,
+    diagnostic.type,
+    diagnostic.code,
+  ])
+
+const getUniqueDiagnostics = (diagnostics: readonly Diagnostic[]): readonly Diagnostic[] => {
+  const keys = new Set<string>()
+  return diagnostics.filter((diagnostic) => {
+    const key = getDiagnosticKey(diagnostic)
+    if (keys.has(key)) {
+      return false
+    }
+    keys.add(key)
+    return true
+  })
+}
 
 export const getProblems = async (workspaceUri: string, activeUri: string): Promise<ProblemsResult> => {
   if (!activeUri) {
@@ -10,10 +34,8 @@ export const getProblems = async (workspaceUri: string, activeUri: string): Prom
     }
   }
   try {
-    const diagnostics = await EditorWorker.getProblems()
-    const activeDiagnostics = diagnostics.filter((diagnostic) => diagnostic.uri === activeUri)
-    // @ts-ignore
-    const problems = toProblems(activeDiagnostics, workspaceUri)
+    const diagnostics = getUniqueDiagnostics(await EditorWorker.getProblems())
+    const problems = toProblems(diagnostics, workspaceUri)
     return {
       error: '',
       problems,

--- a/packages/problems-view/test/GetProblems.test.ts
+++ b/packages/problems-view/test/GetProblems.test.ts
@@ -21,7 +21,7 @@ test('getProblems returns empty array for non-empty state', async () => {
   expect(result).toEqual({ error: '', problems: [] })
 })
 
-test('getProblems only returns diagnostics for the active file', async () => {
+test('getProblems returns cross-file diagnostics while a file is active', async () => {
   EditorWorker.registerMockRpc({
     'Editor.getProblems': () => [
       { message: 'one', uri: 'file:///one.ts' },
@@ -29,8 +29,26 @@ test('getProblems only returns diagnostics for the active file', async () => {
     ],
   })
   const result = await getProblems('', 'file:///two.ts')
+  expect(result.problems).toHaveLength(4)
+  expect(new Set(result.problems.map((problem) => problem.uri))).toEqual(new Set(['file:///one.ts', 'file:///two.ts']))
+})
+
+test('getProblems removes duplicate diagnostics from multiple open editors', async () => {
+  const diagnostic = {
+    code: '',
+    columnIndex: 0,
+    message: 'Invalid config',
+    rowIndex: 1,
+    source: 'eslint',
+    type: 'error',
+    uri: 'file:///eslint.config.js',
+  }
+  EditorWorker.registerMockRpc({
+    'Editor.getProblems': () => [diagnostic, diagnostic],
+  })
+  const result = await getProblems('', 'file:///source.ts')
   expect(result.problems).toHaveLength(2)
-  expect(result.problems.every((problem) => problem.uri === 'file:///two.ts')).toBe(true)
+  expect(result.problems.every((problem) => problem.uri === diagnostic.uri)).toBe(true)
 })
 
 test('getProblems does not query diagnostics when there is no active file', async () => {

--- a/packages/problems-view/test/HandleActiveEditorChange.test.ts
+++ b/packages/problems-view/test/HandleActiveEditorChange.test.ts
@@ -3,7 +3,7 @@ import { EditorWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleActiveEditorChange, handleDiagnosticsChange } from '../src/parts/HandleActiveEditorChange/HandleActiveEditorChange.ts'
 
-test('loads only diagnostics belonging to the newly active file', async () => {
+test('loads cross-file diagnostics when the active file changes', async () => {
   EditorWorker.registerMockRpc({
     'Editor.getProblems': () => [
       { message: 'stale', uri: 'file:///old.ts' },
@@ -12,8 +12,8 @@ test('loads only diagnostics belonging to the newly active file', async () => {
   })
   const result = await handleActiveEditorChange({ ...createDefaultState(), activeUri: 'file:///old.ts' }, 'file:///new.ts')
   expect(result.activeUri).toBe('file:///new.ts')
-  expect(result.problems).toHaveLength(2)
-  expect(result.problems.every((problem) => problem.uri === 'file:///new.ts')).toBe(true)
+  expect(result.problems).toHaveLength(4)
+  expect(new Set(result.problems.map((problem) => problem.uri))).toEqual(new Set(['file:///old.ts', 'file:///new.ts']))
   expect(result.message).toBe('Some problems have been detected in the workspace.')
 })
 

--- a/packages/problems-view/test/LoadContent.test.ts
+++ b/packages/problems-view/test/LoadContent.test.ts
@@ -289,7 +289,7 @@ test('loadContent with one problem', async () => {
   expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
-test('loadContent with problems in multiple files only returns the active file', async () => {
+test('loadContent returns problems from every open file', async () => {
   using mockRpc = registerEditorWorker(
     {
       'Editor.getProblems': () => [
@@ -327,9 +327,9 @@ test('loadContent with problems in multiple files only returns the active file',
   const state: ProblemsState = createDefaultState()
   const savedState = {}
   const result = await loadContent(state, savedState)
-  expect(result.problems).toHaveLength(2)
-  expect(result.filteredProblems).toHaveLength(2)
-  expect(result.problems.every((problem) => problem.uri === 'file:///test2.ts')).toBe(true)
+  expect(result.problems).toHaveLength(6)
+  expect(result.filteredProblems).toHaveLength(6)
+  expect(new Set(result.problems.map((problem) => problem.uri))).toEqual(new Set(['file:///test1.ts', 'file:///test2.ts', 'file:///test3.ts']))
   expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 


### PR DESCRIPTION
## Details

The Problems view filtered the editor diagnostic inventory to the active URI. Correct cross-file diagnostics, such as an ESLint config parse error returned while linting a source document, therefore remained hidden until the config itself became active.

## Change

- show diagnostics from every open editor while a file is active
- preserve the URI supplied by each diagnostic
- deduplicate identical diagnostics returned through multiple open editors
- update active-editor and load-content coverage for workspace-wide results

## Verification

- `npm run type-check`
- `npm run lint`
- `npm test` (309 passed, 1 todo)
- `npm run build`
- `npm run e2e` (154 passed, 4 skipped)