### PR TITLE
fix: build diagnostics fixture before tests

### DIFF
--- a/packages/build/src/dev.ts
+++ b/packages/build/src/dev.ts
@@ -1,7 +1,9 @@
 import { execa } from 'execa'
+import { buildE2eExtensions } from './buildE2eExtensions.ts'
 import { root } from './root.ts'
 
 const main = async (): Promise<void> => {
+  await buildE2eExtensions()
   void execa(`npm`, ['run', 'build:watch'], {
     cwd: root,
     stdio: 'inherit',

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
+    "pree2e": "npm run build --prefix ../..",
     "e2e": "node ../../node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=.",
+    "pree2e:headless": "npm run build --prefix ../..",
     "e2e:headless": "node ../../node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --headless",
     "type-check": "tsc"
   },


### PR DESCRIPTION
Build the isolated diagnostics fixture before starting the development server and before local e2e runs. This prevents the extension worker entrypoint from returning 404 and leaves the Problems view empty on the first run.