### PR TITLE
fix: initialize websocket issuer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
       ],
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.0.0",
-        "@lvce-editor/shared-process": "^0.97.0",
-        "@lvce-editor/static-server": "^0.97.0",
+        "@lvce-editor/shared-process": "^0.99.10",
+        "@lvce-editor/static-server": "^0.99.10",
         "eslint": "^10.8.0",
         "prettier": "^3.9.6",
         "typescript": "^6.0.3"
@@ -2787,9 +2787,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.97.0.tgz",
-      "integrity": "sha512-NYtUBzwQSIP1B+kgMf+KSzmRc2BWUbb8yDOcPcv8oc1OCWX7zT0MyzjTTNV1yjE11HnAPoDEktjxo4OcRj7xRw==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.10.tgz",
+      "integrity": "sha512-yEY6jkgQa75V98cu1ACYCAny513QTMWbC7X7nO//YAEf8ylykCHgS1m7Pm1PdA1A3b7YWbSoxgdzdL7JT0nbBg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -2802,9 +2802,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
-      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
+      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3210,9 +3210,9 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
-      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
+      "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3230,13 +3230,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.97.0.tgz",
-      "integrity": "sha512-WDo32hFiI1nN+2L0F/Y9g1G630PMMRz/ov7nt1iQLtzq6wj7Li9UrC2Woed6ZiRUagoxJVgvACIEZDdKPC/d1w==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.10.tgz",
+      "integrity": "sha512-KA3/DXuvLVcKA+qJ8LtIe7l0BUpnaKtwWFjETOZCMDV9ZPH3bkh8Pzs3ZXvlhr3bODVey9LaHMyFsVmBjZjYfw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.97.0",
-        "@lvce-editor/static-server": "0.97.0"
+        "@lvce-editor/shared-process": "0.99.10",
+        "@lvce-editor/static-server": "0.99.10"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3246,13 +3246,13 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.97.0.tgz",
-      "integrity": "sha512-Slk5s0S3YWtoPgWJOfgYPKByEYGU/gCxOh+afG5uNvsu0rPXrEF7zzKOhrqqr13nn6/xomXuE8BzN4gBEiSYpg==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.10.tgz",
+      "integrity": "sha512-J6OG6o6cNnXRDaP8/TXNazFw2G8+6Dm90B5U/Rg2w21OebcVKvQO5x+CE4pwoOV7/rrC0H8ZeUh5QuyvSu06sg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.97.0",
+        "@lvce-editor/extension-host-helper-process": "0.99.10",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3269,13 +3269,13 @@
       },
       "optionalDependencies": {
         "@lvce-editor/embeds-process": "4.15.0",
-        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-system-process": "5.12.0",
         "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
         "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/search-process": "15.7.0",
         "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
@@ -3284,9 +3284,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.97.0.tgz",
-      "integrity": "sha512-ZGIA7osYhn3p5DdQFL4dppnaXS2aX11l9AoQg1SsnbADziYLrB84G0NYaFICNOKTp9SF02KZ8IZiLcSgTmzZ2A==",
+      "version": "0.99.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.10.tgz",
+      "integrity": "sha512-f0/HUo95CqeOgId1Kn8colspaGqDyAIYApW0TSilxh6vEhLes+dtaZDx8Lg5LulLTzQRCtDGqz3LT0TkmzUBeA==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -14399,7 +14399,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.97.0"
+        "@lvce-editor/server": "0.99.10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.0.0",
-    "@lvce-editor/shared-process": "^0.97.0",
-    "@lvce-editor/static-server": "^0.97.0",
+    "@lvce-editor/shared-process": "^0.99.10",
+    "@lvce-editor/static-server": "^0.99.10",
     "eslint": "^10.8.0",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3"

--- a/packages/problems-view/src/parts/GetWorkspacePath/GetWorkspacePath.ts
+++ b/packages/problems-view/src/parts/GetWorkspacePath/GetWorkspacePath.ts
@@ -1,0 +1,5 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const getWorkspacePath = (): Promise<string> => {
+  return RendererWorker.getWorkspacePath()
+}

--- a/packages/problems-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/problems-view/src/parts/LoadContent/LoadContent.ts
@@ -5,12 +5,13 @@ import * as GetProblems from '../GetProblems/GetProblems.ts'
 import * as GetSavedCollapsedUris from '../GetSavedCollapsedUris/GetSavedCollapsedUris.ts'
 import * as GetSavedFilterValue from '../GetSavedFilterValue/GetSavedFilterValue.ts'
 import * as GetSavedViewMode from '../GetSavedViewMode/GetSavedViewMode.ts'
+import * as GetWorkspacePath from '../GetWorkspacePath/GetWorkspacePath.ts'
 import * as InputSource from '../InputSource/InputSource.ts'
 import * as ViewletProblemsStrings from '../ProblemStrings/ProblemStrings.ts'
 
 export const loadContent = async (state: ProblemsState, savedState: any): Promise<ProblemsState> => {
-  const { fileIconCache: oldFileIconCache, workspaceUri } = state
-  const activeUri = await GetActiveUri.getActiveUri()
+  const { fileIconCache: oldFileIconCache } = state
+  const [activeUri, workspaceUri] = await Promise.all([GetActiveUri.getActiveUri(), GetWorkspacePath.getWorkspacePath()])
   const { error, problems } = await GetProblems.getProblems(workspaceUri, activeUri)
   if (error) {
     return {
@@ -19,6 +20,7 @@ export const loadContent = async (state: ProblemsState, savedState: any): Promis
       filteredProblems: [],
       message: error,
       problems: [],
+      workspaceUri,
     }
   }
   const message = ViewletProblemsStrings.getMessage(problems.length)
@@ -38,5 +40,6 @@ export const loadContent = async (state: ProblemsState, savedState: any): Promis
     message,
     problems,
     viewMode,
+    workspaceUri,
   }
 }

--- a/packages/problems-view/test/LoadContent.test.ts
+++ b/packages/problems-view/test/LoadContent.test.ts
@@ -9,6 +9,7 @@ import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMod
 RendererWorker.registerMockRpc({
   'GetActiveEditor.getActiveEditorId': () => 1,
   'IconTheme.getFileIcon': ({ name }: Readonly<{ name: string }>) => `/icons/${name}.svg`,
+  'Workspace.getPath': () => 'file:///workspace',
 })
 
 const registerEditorWorker = (
@@ -42,7 +43,7 @@ test('loadContent returns a new state with expected properties', async () => {
   expect(mockRpc.invocations).toEqual([['Editor.getUri', 1], ['Editor.getProblems']])
 })
 
-test('loadContent preserves state properties', async () => {
+test('loadContent preserves state properties and refreshes the workspace uri', async () => {
   using mockRpc = registerEditorWorker({
     'Editor.getProblems': () => [],
   })
@@ -51,7 +52,7 @@ test('loadContent preserves state properties', async () => {
     focusedIndex: 5,
     height: 200,
     width: 100,
-    workspaceUri: 'file:///workspace',
+    workspaceUri: 'file:///stale-workspace',
   }
   const savedState = {}
   const result = await loadContent(state, savedState)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,6 @@
     "dev": "node ../../node_modules/@lvce-editor/server/bin/server.js --test-path=../e2e"
   },
   "dependencies": {
-    "@lvce-editor/server": "0.97.0"
+    "@lvce-editor/server": "0.99.10"
   }
 }


### PR DESCRIPTION
Update the LVCE server stack so each document receives an initialized websocket issuer.

Refresh the live workspace path while loading Problems to preserve relative diagnostic labels with the newer renderer lifecycle.