### PR TITLE
fix: enable problems scrollbar dragging

### DIFF
--- a/packages/problems-view/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/problems-view/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -60,6 +60,7 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
       name: DomEventListenerFunctions.HandleScrollBarPointerDown,
       params: ['handleScrollBarClick', EventExpression.ClientY],
       preventDefault: true,
+      stopPropagation: true,
       trackPointerEvents: [DomEventListenerFunctions.HandleScrollBarMove, DomEventListenerFunctions.HandleScrollBarPointerCaptureLost],
     } as DomEventListener,
     {

--- a/packages/problems-view/test/RenderEventListeners.test.ts
+++ b/packages/problems-view/test/RenderEventListeners.test.ts
@@ -36,3 +36,19 @@ test('renderEventListeners registers the problems toolbar actions', () => {
     ]),
   )
 })
+
+test('renderEventListeners keeps scrollbar pointerdown from selecting a problem', () => {
+  const result = renderEventListeners()
+
+  expect(result).toEqual(
+    expect.arrayContaining([
+      {
+        name: DomEventListenerFunctions.HandleScrollBarPointerDown,
+        params: ['handleScrollBarClick', EventExpression.ClientY],
+        preventDefault: true,
+        stopPropagation: true,
+        trackPointerEvents: [DomEventListenerFunctions.HandleScrollBarMove, DomEventListenerFunctions.HandleScrollBarPointerCaptureLost],
+      },
+    ]),
+  )
+})


### PR DESCRIPTION
Summary:
- keep scrollbar pointerdown events from bubbling into problem row selection
- preserve the active pointer-tracking state so dragging updates the Problems scroll position