### PR TITLE
fix: focus editor when clicking problem

### DIFF
--- a/packages/build/src/buildE2eExtensions.ts
+++ b/packages/build/src/buildE2eExtensions.ts
@@ -16,5 +16,6 @@ const buildE2eExtension = async (extensionName: string): Promise<void> => {
 }
 
 export const buildE2eExtensions = async (): Promise<void> => {
+  await buildE2eExtension('problems.click-focuses-editor')
   await buildE2eExtension('problems.one-problem')
 }

--- a/packages/e2e/fixtures/problems.click-focuses-editor/extension.json
+++ b/packages/e2e/fixtures/problems.click-focuses-editor/extension.json
@@ -1,0 +1,17 @@
+{
+  "browser": "dist/main.js",
+  "isolated": true,
+  "diagnosticProviders": [
+    {
+      "id": "xyz-diagnostics",
+      "languageId": "xyz"
+    }
+  ],
+  "languages": [
+    {
+      "id": "xyz",
+      "extensions": [".xyz"]
+    }
+  ],
+  "activation": ["onDiagnostic:xyz"]
+}

--- a/packages/e2e/fixtures/problems.click-focuses-editor/main.js
+++ b/packages/e2e/fixtures/problems.click-focuses-editor/main.js
@@ -1,0 +1,23 @@
+import { activate as activateExtensionApi, registerDiagnosticProvider } from '@lvce-editor/api'
+
+const diagnosticProvider = {
+  id: 'xyz-diagnostics',
+  languageId: 'xyz',
+  provideDiagnostics(textDocument, offset) {
+    return [
+      {
+        uri: textDocument.uri,
+        rowIndex: 1,
+        columnIndex: 3,
+        endRowIndex: 1,
+        endColumnIndex: 3,
+        message: 'error 1',
+        source: 'xyz',
+        type: 'error',
+      },
+    ]
+  },
+}
+
+await activateExtensionApi()
+registerDiagnosticProvider(diagnosticProvider)

--- a/packages/e2e/fixtures/problems.click-focuses-editor/main.js
+++ b/packages/e2e/fixtures/problems.click-focuses-editor/main.js
@@ -8,9 +8,9 @@ const diagnosticProvider = {
       {
         uri: textDocument.uri,
         rowIndex: 1,
-        columnIndex: 3,
+        columnIndex: 0,
         endRowIndex: 1,
-        endColumnIndex: 3,
+        endColumnIndex: 0,
         message: 'error 1',
         source: 'xyz',
         type: 'error',

--- a/packages/e2e/src/problems.click-focuses-editor.ts
+++ b/packages/e2e/src/problems.click-focuses-editor.ts
@@ -2,7 +2,21 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'problems.click-focuses-editor'
 
-export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locator, Main, Panel, Workspace }) => {
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locator, Main, Panel, Problems, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   const fileUri = `${tmpDir}/file1.xyz`
   await FileSystem.writeFile(fileUri, 'first line\nsecond line')
@@ -15,10 +29,11 @@ export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locato
 
   const problems = Locator('.Problem')
   await expect(problems).toHaveCount(2)
-  // eslint-disable-next-line e2e/no-direct-click -- This regression test must exercise the rendered problem row's pointer handler.
-  await problems.nth(1).click()
+  await Problems.handleClickAt(10, 616)
 
-  await Editor.shouldHaveSelections(new Uint32Array([1, 3, 1, 3]))
+  const cursor = Locator('.EditorCursor')
+  await expect(cursor).toBeVisible()
+  await waitFor(() => expect(cursor).toHaveCSS('translate', '0px 20px'))
   const editorInput = Locator('[name="editor"]')
-  await expect(editorInput).toBeFocused()
+  await waitFor(() => expect(editorInput).toBeFocused())
 }

--- a/packages/e2e/src/problems.click-focuses-editor.ts
+++ b/packages/e2e/src/problems.click-focuses-editor.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.click-focuses-editor'
+
+export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locator, Main, Panel, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const fileUri = `${tmpDir}/file1.xyz`
+  await FileSystem.writeFile(fileUri, 'first line\nsecond line')
+  await Workspace.setPath(tmpDir)
+  // @ts-ignore
+  await Extension.addWebExtension(new URL(`../fixtures/${name}`, import.meta.url).toString())
+  await Main.openUri(fileUri)
+  await Editor.setCursor(0, 0)
+  await Panel.openProblems()
+
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+  // eslint-disable-next-line e2e/no-direct-click -- This regression test must exercise the rendered problem row's pointer handler.
+  await problems.nth(1).click()
+
+  await Editor.shouldHaveSelections(new Uint32Array([1, 3, 1, 3]))
+  const editorInput = Locator('[name="editor"]')
+  await expect(editorInput).toBeFocused()
+}

--- a/packages/problems-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/problems-view/src/parts/CommandMap/CommandMap.ts
@@ -11,12 +11,12 @@ import { handleActiveEditorChange, handleDiagnosticsChange } from '../HandleActi
 import * as HandleArrowLeft from '../HandleArrowLeft/HandleArrowLeft.ts'
 import * as HandleArrowRight from '../HandleArrowRight/HandleArrowRight.ts'
 import * as HandleBlur from '../HandleBlur/HandleBlur.ts'
-import { handleClickAt } from '../HandleClickAt/HandleClickAt.ts'
 import { handleClickButton } from '../HandleClickButton/HandleClickButton.ts'
 import { handleClickMoreFilters } from '../HandleClickMoreFilters/HandleClickMoreFilters.ts'
 import { handleContextMenu } from '../HandleContextMenu/HandleContextMenu.ts'
 import * as HandleFilterInput from '../HandleFilterInput/HandleFilterInput.ts'
 import { handleIconThemeChange } from '../HandleIconThemeChange/HandleIconThemeChange.ts'
+import { handleProblemClick } from '../HandleProblemClick/HandleProblemClick.ts'
 import { handleScrollBarCaptureLost } from '../HandleScrollBarCaptureLost/HandleScrollBarCaptureLost.ts'
 import { handleScrollBarClick } from '../HandleScrollBarClick/HandleScrollBarClick.ts'
 import { handleScrollBarMove } from '../HandleScrollBarMove/HandleScrollBarMove.ts'
@@ -48,7 +48,7 @@ export const commandMap = {
   'Problems.handleArrowLeft': WrapCommand.wrapCommand(HandleArrowLeft.handleArrowLeft),
   'Problems.handleArrowRight': WrapCommand.wrapCommand(HandleArrowRight.handleArrowRight),
   'Problems.handleBlur': WrapCommand.wrapCommand(HandleBlur.handleBlur),
-  'Problems.handleClickAt': WrapCommand.wrapCommand(handleClickAt),
+  'Problems.handleClickAt': WrapCommand.wrapCommand(handleProblemClick),
   'Problems.handleClickButton': WrapCommand.wrapCommand(handleClickButton),
   'Problems.handleClickMoreFilters': WrapCommand.wrapCommand(handleClickMoreFilters),
   'Problems.handleContextMenu': WrapCommand.wrapCommand(handleContextMenu),

--- a/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
+++ b/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
@@ -26,8 +26,8 @@ export const handleProblemClick = async (state: ProblemsState, eventX: number, e
     return newState
   }
   const { columnIndex, rowIndex, uri } = problem
-  await RendererWorker.openUri(uri, true, {
-    selections: new Uint32Array([rowIndex, columnIndex, rowIndex, columnIndex]),
-  })
+  await RendererWorker.openUri(uri, true)
+  await RendererWorker.focusEditor()
+  await RendererWorker.setEditorCursor(rowIndex, columnIndex)
   return newState
 }

--- a/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
+++ b/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
@@ -1,0 +1,33 @@
+import type { ProblemsState } from '../ProblemsState/ProblemsState.ts'
+import * as GetVisibleProblems from '../GetVisibleProblems/GetVisibleProblems.ts'
+import { handleClickAt } from '../HandleClickAt/HandleClickAt.ts'
+import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType.ts'
+import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
+
+export const handleProblemClick = async (state: ProblemsState, eventX: number, eventY: number): Promise<ProblemsState> => {
+  const newState = handleClickAt(state, eventX, eventY)
+  const { focusedIndex } = newState
+  if (focusedIndex < 0) {
+    return newState
+  }
+  const { collapsedUris, fileIconCache, filterValue, problems, viewMode } = newState
+  const visibleProblems = GetVisibleProblems.getVisibleProblems(
+    problems,
+    fileIconCache,
+    collapsedUris,
+    focusedIndex,
+    filterValue,
+    focusedIndex,
+    focusedIndex + 1,
+    viewMode,
+  )
+  const problem = visibleProblems[0]
+  if (!problem || problem.listItemType !== ProblemListItemType.Item) {
+    return newState
+  }
+  const { columnIndex, rowIndex, uri } = problem
+  await RendererWorker.openUri(uri, true, {
+    selections: new Uint32Array([rowIndex, columnIndex, rowIndex, columnIndex]),
+  })
+  return newState
+}

--- a/packages/problems-view/src/parts/RendererWorker/RendererWorker.ts
+++ b/packages/problems-view/src/parts/RendererWorker/RendererWorker.ts
@@ -5,8 +5,16 @@ export const getActiveEditorId = (): Promise<number> => {
   return RendererWorker.getActiveEditorId()
 }
 
-export const openUri = (uri: string, focus: boolean, options: unknown): Promise<void> => {
-  return RendererWorker.openUri(uri, focus, options)
+export const focusEditor = async (): Promise<void> => {
+  await RendererWorker.invoke('Main.focus')
+}
+
+export const openUri = (uri: string, focus: boolean): Promise<void> => {
+  return RendererWorker.openUri(uri, focus)
+}
+
+export const setEditorCursor = async (rowIndex: number, columnIndex: number): Promise<void> => {
+  await RendererWorker.invoke('Editor.cursorSet', rowIndex, columnIndex)
 }
 
 export const sendMessagePortToEditorWorker = (port: any, rpcId: number): Promise<void> => {

--- a/packages/problems-view/src/parts/RendererWorker/RendererWorker.ts
+++ b/packages/problems-view/src/parts/RendererWorker/RendererWorker.ts
@@ -5,6 +5,10 @@ export const getActiveEditorId = (): Promise<number> => {
   return RendererWorker.getActiveEditorId()
 }
 
+export const openUri = (uri: string, focus: boolean, options: unknown): Promise<void> => {
+  return RendererWorker.openUri(uri, focus, options)
+}
+
 export const sendMessagePortToEditorWorker = (port: any, rpcId: number): Promise<void> => {
   return RendererWorker.sendMessagePortToEditorWorker(port, rpcId)
 }

--- a/packages/problems-view/test/HandleProblemClick.test.ts
+++ b/packages/problems-view/test/HandleProblemClick.test.ts
@@ -7,7 +7,9 @@ import * as ProblemListItemType from '../src/parts/ProblemListItemType/ProblemLi
 import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
 
 test('opens and focuses the clicked problem at its position', async () => {
-  using mockRpc = RendererWorker.registerMockRpc({
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'Editor.cursorSet': async () => {},
+    'Main.focus': async () => {},
     'Main.openUri': async () => {},
   })
   const state: ProblemsState = {
@@ -38,20 +40,15 @@ test('opens and focuses the clicked problem at its position', async () => {
   const result = await handleProblemClick(state, 50, 11)
 
   expect(result.focusedIndex).toBe(0)
-  expect(mockRpc.invocations).toEqual([
-    [
-      'Main.openUri',
-      {
-        focus: true,
-        selections: new Uint32Array([4, 7, 4, 7]),
-        uri: 'file:///workspace/test.ts',
-      },
-    ],
+  expect(rendererRpc.invocations).toEqual([
+    ['Main.openUri', { focus: true, uri: 'file:///workspace/test.ts' }],
+    ['Main.focus'],
+    ['Editor.cursorSet', 4, 7],
   ])
 })
 
 test('does not open a file when clicking a problem group', async () => {
-  using mockRpc = RendererWorker.registerMockRpc({
+  using rendererRpc = RendererWorker.registerMockRpc({
     'Main.openUri': async () => {},
   })
   const state: ProblemsState = {
@@ -82,5 +79,5 @@ test('does not open a file when clicking a problem group', async () => {
   const result = await handleProblemClick(state, 50, 11)
 
   expect(result.focusedIndex).toBe(0)
-  expect(mockRpc.invocations).toEqual([])
+  expect(rendererRpc.invocations).toEqual([])
 })

--- a/packages/problems-view/test/HandleProblemClick.test.ts
+++ b/packages/problems-view/test/HandleProblemClick.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { ProblemsState } from '../src/parts/ProblemsState/ProblemsState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleProblemClick } from '../src/parts/HandleProblemClick/HandleProblemClick.ts'
 import * as ProblemListItemType from '../src/parts/ProblemListItemType/ProblemListItemType.ts'
-import type { ProblemsState } from '../src/parts/ProblemsState/ProblemsState.ts'
 import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
 
 test('opens and focuses the clicked problem at its position', async () => {

--- a/packages/problems-view/test/HandleProblemClick.test.ts
+++ b/packages/problems-view/test/HandleProblemClick.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleProblemClick } from '../src/parts/HandleProblemClick/HandleProblemClick.ts'
+import * as ProblemListItemType from '../src/parts/ProblemListItemType/ProblemListItemType.ts'
+import type { ProblemsState } from '../src/parts/ProblemsState/ProblemsState.ts'
+import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
+
+test('opens and focuses the clicked problem at its position', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUri': async () => {},
+  })
+  const state: ProblemsState = {
+    ...createDefaultState(),
+    itemHeight: 22,
+    problems: [
+      {
+        code: '',
+        columnIndex: 7,
+        count: 0,
+        fileName: 'test.ts',
+        level: 2,
+        listItemType: ProblemListItemType.Item,
+        message: 'problem',
+        posInSet: 1,
+        relativePath: '',
+        rowIndex: 4,
+        setSize: 1,
+        source: 'test',
+        type: 'error',
+        uri: 'file:///workspace/test.ts',
+      },
+    ],
+    viewMode: ProblemsViewMode.List,
+    width: 800,
+  }
+
+  const result = await handleProblemClick(state, 50, 11)
+
+  expect(result.focusedIndex).toBe(0)
+  expect(mockRpc.invocations).toEqual([
+    [
+      'Main.openUri',
+      {
+        focus: true,
+        selections: new Uint32Array([4, 7, 4, 7]),
+        uri: 'file:///workspace/test.ts',
+      },
+    ],
+  ])
+})
+
+test('does not open a file when clicking a problem group', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUri': async () => {},
+  })
+  const state: ProblemsState = {
+    ...createDefaultState(),
+    itemHeight: 22,
+    problems: [
+      {
+        code: '',
+        columnIndex: 0,
+        count: 1,
+        fileName: 'test.ts',
+        level: 1,
+        listItemType: ProblemListItemType.Expanded,
+        message: '',
+        posInSet: 1,
+        relativePath: '',
+        rowIndex: 0,
+        setSize: 1,
+        source: '',
+        type: '',
+        uri: 'file:///workspace/test.ts',
+      },
+    ],
+    viewMode: ProblemsViewMode.List,
+    width: 800,
+  }
+
+  const result = await handleProblemClick(state, 50, 11)
+
+  expect(result.focusedIndex).toBe(0)
+  expect(mockRpc.invocations).toEqual([])
+})


### PR DESCRIPTION
Clicking a diagnostic in the Problems view now opens and focuses its editor with the cursor at the reported position. Adds worker-level regression coverage and an integrated e2e test for cursor placement and editor focus.