### PR TITLE
fix: toggle problem severity filters

### DIFF
--- a/packages/e2e/src/problems.context-menu-toggle-errors.ts
+++ b/packages/e2e/src/problems.context-menu-toggle-errors.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.context-menu-toggle-errors'
+
+export const test: Test = async ({ ContextMenu, expect, Extension, FileSystem, Locator, Main, Panel, Problems, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.xyz`, 'content 1')
+  await Workspace.setPath(tmpDir)
+  // @ts-ignore
+  await Extension.addWebExtension(new URL('../fixtures/problems.one-problem', import.meta.url).toString())
+  await Main.openUri(`${tmpDir}/file1.xyz`)
+  await Panel.openProblems()
+
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(2)
+
+  await Problems.handleContextMenu(0, 0)
+  await ContextMenu.selectItem('Show Errors')
+  await expect(problems).toHaveCount(0)
+
+  await Problems.handleContextMenu(0, 0)
+  await ContextMenu.selectItem('Show Errors')
+  await expect(problems).toHaveCount(2)
+}

--- a/packages/problems-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/problems-view/src/parts/CommandMap/CommandMap.ts
@@ -31,6 +31,9 @@ import { renderEventListeners } from '../RenderEventListeners/RenderEventListene
 import * as Resize from '../Resize/Resize.ts'
 import * as SaveState from '../SaveState/SaveState.ts'
 import { toggleFileGroup } from '../ToggleFileGroup/ToggleFileGroup.ts'
+import { toggleShowErrors } from '../ToggleShowErrors/ToggleShowErrors.ts'
+import { toggleShowInfos } from '../ToggleShowInfos/ToggleShowInfos.ts'
+import { toggleShowWarnings } from '../ToggleShowWarnings/ToggleShowWarnings.ts'
 import { viewAsList } from '../ViewAsList/ViewAsList.ts'
 import { viewAsTable } from '../ViewAsTable/ViewAsTable.ts'
 
@@ -68,6 +71,9 @@ export const commandMap = {
   'Problems.saveState': WrapCommand.wrapGetter(SaveState.saveState),
   'Problems.terminate': ViewletRegistry.terminate,
   'Problems.toggleFileGroup': WrapCommand.wrapCommand(toggleFileGroup),
+  'Problems.toggleShowErrors': WrapCommand.wrapCommand(toggleShowErrors),
+  'Problems.toggleShowInfos': WrapCommand.wrapCommand(toggleShowInfos),
+  'Problems.toggleShowWarnings': WrapCommand.wrapCommand(toggleShowWarnings),
   'Problems.viewAsList': WrapCommand.wrapCommand(viewAsList),
   'Problems.viewAsTable': WrapCommand.wrapCommand(viewAsTable),
 }

--- a/packages/problems-view/src/parts/DiffCss/DiffCss.ts
+++ b/packages/problems-view/src/parts/DiffCss/DiffCss.ts
@@ -11,6 +11,9 @@ export const isEqual = (oldState: ProblemsState, newState: ProblemsState): boole
     oldState.maxLineY === newState.maxLineY &&
     oldState.minLineY === newState.minLineY &&
     oldState.problems === newState.problems &&
+    oldState.showErrors === newState.showErrors &&
+    oldState.showInfos === newState.showInfos &&
+    oldState.showWarnings === newState.showWarnings &&
     oldState.scrollBarHeight === newState.scrollBarHeight &&
     oldState.viewMode === newState.viewMode &&
     oldState.width === newState.width

--- a/packages/problems-view/src/parts/DiffItems/DiffItems.ts
+++ b/packages/problems-view/src/parts/DiffItems/DiffItems.ts
@@ -22,6 +22,9 @@ export const isEqual = (oldState: ProblemsState, newState: ProblemsState): boole
     oldState.maxLineY === newState.maxLineY &&
     oldState.minLineY === newState.minLineY &&
     oldState.problems === newState.problems &&
+    oldState.showErrors === newState.showErrors &&
+    oldState.showInfos === newState.showInfos &&
+    oldState.showWarnings === newState.showWarnings &&
     oldState.filterValue === newState.filterValue &&
     oldState.message === newState.message &&
     oldState.scrollBarActive === newState.scrollBarActive &&

--- a/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
+++ b/packages/problems-view/src/parts/FilterProblems/FilterProblems.ts
@@ -1,14 +1,46 @@
 import type { FilteredProblem } from '../FilteredProblem/FilteredProblem.ts'
 import type { Problem } from '../Problem/Problem.ts'
+import * as DiagnosticType from '../DiagnosticType/DiagnosticType.ts'
 import { getListItemType } from '../GetListItemType/GetListItemType.ts'
 import { matchesFilterValue } from '../MatchesFilterValue/MatchesFilterValue.ts'
 import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType.ts'
 
-export const filterProblems = (problems: readonly Problem[], collapsedUris: readonly string[], filterValue: string): readonly FilteredProblem[] => {
+const matchesSeverity = (problem: Problem, showErrors: boolean, showWarnings: boolean, showInfos: boolean): boolean => {
+  switch (problem.type) {
+    case DiagnosticType.Error:
+      return showErrors
+    case DiagnosticType.Warning:
+      return showWarnings
+    default:
+      return showInfos
+  }
+}
+
+export const filterProblems = (
+  problems: readonly Problem[],
+  collapsedUris: readonly string[],
+  filterValue: string,
+  showErrors = true,
+  showWarnings = true,
+  showInfos = true,
+): readonly FilteredProblem[] => {
   const filterValueLower = filterValue.toLowerCase()
   const collapsedUriSet = new Set(collapsedUris)
+  const hasSeverityFilter = !showErrors || !showWarnings || !showInfos
+  const visibleUris = new Set(
+    problems
+      .filter((problem) => problem.listItemType === ProblemListItemType.Item && matchesSeverity(problem, showErrors, showWarnings, showInfos))
+      .map((problem) => problem.uri),
+  )
   const filtered = []
   for (const problem of problems) {
+    if (problem.listItemType === ProblemListItemType.Item) {
+      if (!matchesSeverity(problem, showErrors, showWarnings, showInfos)) {
+        continue
+      }
+    } else if (hasSeverityFilter && !visibleUris.has(problem.uri)) {
+      continue
+    }
     const uriMatchIndex = matchesFilterValue(problem.uri, filterValueLower)
     const sourceMatchIndex = matchesFilterValue(problem.source, filterValueLower)
     const messageMatchIndex = matchesFilterValue(problem.message, filterValueLower)

--- a/packages/problems-view/src/parts/GetMenuEntriesFilter/GetMenuEntriesFilter.ts
+++ b/packages/problems-view/src/parts/GetMenuEntriesFilter/GetMenuEntriesFilter.ts
@@ -7,19 +7,19 @@ export const getMenuEntriesFilter = (state: ProblemsState): readonly MenuEntry[]
   const { showErrors, showInfos, showWarnings } = state
   return [
     {
-      command: '-1',
+      command: 'Problems.toggleShowErrors',
       flags: showErrors ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
       id: 'show-errors',
       label: ProblemStrings.showErrors(),
     },
     {
-      command: '-1',
+      command: 'Problems.toggleShowWarnings',
       flags: showWarnings ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
       id: 'show-warnings',
       label: ProblemStrings.showWarnings(),
     },
     {
-      command: '-1',
+      command: 'Problems.toggleShowInfos',
       flags: showInfos ? MenuItemFlags.Checked : MenuItemFlags.Unchecked,
       id: 'show-infos',
       label: ProblemStrings.showInfos(),

--- a/packages/problems-view/src/parts/GetProblemActions/GetProblemActions.ts
+++ b/packages/problems-view/src/parts/GetProblemActions/GetProblemActions.ts
@@ -10,7 +10,20 @@ import * as ProblemStrings from '../ProblemStrings/ProblemStrings.ts'
 import * as ProblemsViewMode from '../ProblemsViewMode/ProblemsViewMode.ts'
 
 export const getActions = (state: ProblemsState): readonly ViewletAction[] => {
-  const { collapsedUris, fileIconCache, filterValue, focusedIndex, inputSource, problems, smallWidthBreakPoint, viewMode, width } = state
+  const {
+    collapsedUris,
+    fileIconCache,
+    filterValue,
+    focusedIndex,
+    inputSource,
+    problems,
+    showErrors,
+    showInfos,
+    showWarnings,
+    smallWidthBreakPoint,
+    viewMode,
+    width,
+  } = state
   const visibleCount = GetVisibleProblems.getVisibleProblems(
     problems,
     fileIconCache,
@@ -20,6 +33,9 @@ export const getActions = (state: ProblemsState): readonly ViewletAction[] => {
     0,
     Infinity,
     viewMode,
+    showErrors,
+    showWarnings,
+    showInfos,
   ).length
   const problemsCount = problems.length
   const isSmall = width <= smallWidthBreakPoint

--- a/packages/problems-view/src/parts/GetVisibleProblemCount/GetVisibleProblemCount.ts
+++ b/packages/problems-view/src/parts/GetVisibleProblemCount/GetVisibleProblemCount.ts
@@ -7,8 +7,11 @@ export const getVisibleProblemCount = (
   collapsedUris: readonly string[],
   filterValue: string,
   viewMode: number,
+  showErrors = true,
+  showWarnings = true,
+  showInfos = true,
 ): number => {
-  const filtered = FilterProblems.filterProblems(problems, collapsedUris, filterValue)
+  const filtered = FilterProblems.filterProblems(problems, collapsedUris, filterValue, showErrors, showWarnings, showInfos)
   if (viewMode !== ProblemsViewMode.Table) {
     return filtered.length
   }

--- a/packages/problems-view/src/parts/GetVisibleProblems/GetVisibleProblems.ts
+++ b/packages/problems-view/src/parts/GetVisibleProblems/GetVisibleProblems.ts
@@ -15,6 +15,9 @@ export const getVisibleProblems = (
   minLineY = 0,
   maxLineY = Infinity,
   viewMode = ProblemsViewMode.List,
+  showErrors = true,
+  showWarnings = true,
+  showInfos = true,
 ): readonly VisibleProblem[] => {
   Assert.array(problems)
   Assert.array(collapsedUris)
@@ -22,7 +25,7 @@ export const getVisibleProblems = (
   Assert.string(filterValue)
   const visibleItems = []
   const filterValueLength = filterValue.length
-  const filtered = FilterProblems.filterProblems(problems, collapsedUris, filterValue)
+  const filtered = FilterProblems.filterProblems(problems, collapsedUris, filterValue, showErrors, showWarnings, showInfos)
   const displayProblems = viewMode === ProblemsViewMode.Table ? filtered.filter((problem) => problem.message) : filtered
   const finalLineY = Math.min(maxLineY, displayProblems.length)
   for (let i = minLineY; i < finalLineY; i++) {

--- a/packages/problems-view/src/parts/HandleClickAt/HandleClickAt.ts
+++ b/packages/problems-view/src/parts/HandleClickAt/HandleClickAt.ts
@@ -5,11 +5,33 @@ import * as GetListIndex from '../GetListIndex/GetListIndex.ts'
 import * as GetVisibleProblemCount from '../GetVisibleProblemCount/GetVisibleProblemCount.ts'
 
 export const handleClickAt = (state: ProblemsState, eventX: number, eventY: number): ProblemsState => {
-  const { collapsedUris, deltaY, filterValue, itemHeight, problems, smallWidthBreakPoint, viewMode, width, x, y } = state
+  const {
+    collapsedUris,
+    deltaY,
+    filterValue,
+    itemHeight,
+    problems,
+    showErrors,
+    showInfos,
+    showWarnings,
+    smallWidthBreakPoint,
+    viewMode,
+    width,
+    x,
+    y,
+  } = state
 
   // TODO use functional focus rendering
   // Focus.setFocus(FocusKey.Problems)
-  const problemCount = GetVisibleProblemCount.getVisibleProblemCount(problems, collapsedUris, filterValue, viewMode)
+  const problemCount = GetVisibleProblemCount.getVisibleProblemCount(
+    problems,
+    collapsedUris,
+    filterValue,
+    viewMode,
+    showErrors,
+    showWarnings,
+    showInfos,
+  )
   if (problemCount === 0) {
     return focusIndex(state, -1)
   }

--- a/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
+++ b/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
@@ -10,7 +10,7 @@ export const handleProblemClick = async (state: ProblemsState, eventX: number, e
   if (focusedIndex < 0) {
     return newState
   }
-  const { collapsedUris, fileIconCache, filterValue, problems, viewMode } = newState
+  const { collapsedUris, fileIconCache, filterValue, problems, showErrors, showInfos, showWarnings, viewMode } = newState
   const visibleProblems = GetVisibleProblems.getVisibleProblems(
     problems,
     fileIconCache,
@@ -20,6 +20,9 @@ export const handleProblemClick = async (state: ProblemsState, eventX: number, e
     focusedIndex,
     focusedIndex + 1,
     viewMode,
+    showErrors,
+    showWarnings,
+    showInfos,
   )
   const problem = visibleProblems[0]
   if (!problem || problem.listItemType !== ProblemListItemType.Item) {

--- a/packages/problems-view/src/parts/RenderCss/RenderCss.ts
+++ b/packages/problems-view/src/parts/RenderCss/RenderCss.ts
@@ -21,6 +21,9 @@ export const renderCss = (oldState: ProblemsState, newState: ProblemsState): Vie
     minLineY,
     problems,
     scrollBarHeight,
+    showErrors,
+    showInfos,
+    showWarnings,
     smallWidthBreakPoint,
     uid,
     viewMode,
@@ -35,6 +38,9 @@ export const renderCss = (oldState: ProblemsState, newState: ProblemsState): Vie
     minLineY,
     maxLineY,
     viewMode,
+    showErrors,
+    showWarnings,
+    showInfos,
   )
   const uniqueIndents = GetUniqueIndents.getUniqueIndents(visibleProblems)
   const listHeight = GetListHeight.getListHeight(height, width, smallWidthBreakPoint, viewMode)

--- a/packages/problems-view/src/parts/RenderItems/RenderItems.ts
+++ b/packages/problems-view/src/parts/RenderItems/RenderItems.ts
@@ -18,11 +18,22 @@ export const renderItems = (oldState: ProblemsState, newState: ProblemsState): V
     problems,
     scrollBarActive,
     scrollBarHeight,
+    showErrors,
+    showInfos,
+    showWarnings,
     smallWidthBreakPoint,
     viewMode,
     width,
   } = newState
-  const problemCount = GetVisibleProblemCount.getVisibleProblemCount(problems, collapsedUris, filterValue, viewMode)
+  const problemCount = GetVisibleProblemCount.getVisibleProblemCount(
+    problems,
+    collapsedUris,
+    filterValue,
+    viewMode,
+    showErrors,
+    showWarnings,
+    showInfos,
+  )
   const visible = GetVisibleProblems.getVisibleProblems(
     problems,
     fileIconCache,
@@ -32,6 +43,9 @@ export const renderItems = (oldState: ProblemsState, newState: ProblemsState): V
     minLineY,
     maxLineY,
     viewMode,
+    showErrors,
+    showWarnings,
+    showInfos,
   )
   const isSmall = width <= smallWidthBreakPoint
   const dom = GetProblemsVirtualDom.getProblemsVirtualDom(

--- a/packages/problems-view/src/parts/UpdateVirtualList/UpdateVirtualList.ts
+++ b/packages/problems-view/src/parts/UpdateVirtualList/UpdateVirtualList.ts
@@ -13,11 +13,14 @@ export const updateVirtualList = (state: ProblemsState, newDeltaY?: number): Pro
     itemHeight,
     minimumSliderSize,
     problems,
+    showErrors,
+    showInfos,
+    showWarnings,
     smallWidthBreakPoint,
     viewMode,
     width,
   } = state
-  const itemCount = GetVisibleProblemCount.getVisibleProblemCount(problems, collapsedUris, filterValue, viewMode)
+  const itemCount = GetVisibleProblemCount.getVisibleProblemCount(problems, collapsedUris, filterValue, viewMode, showErrors, showWarnings, showInfos)
   const listHeight = GetListHeight.getListHeight(height, width, smallWidthBreakPoint, viewMode)
   const contentHeight = itemCount * itemHeight
   const finalDeltaY = Math.max(contentHeight - listHeight, 0)

--- a/packages/problems-view/test/DiffCss.test.ts
+++ b/packages/problems-view/test/DiffCss.test.ts
@@ -44,3 +44,10 @@ test('isEqual returns false when collapsed uris change', () => {
   const newState = { ...oldState, collapsedUris: ['file:///file.ts'] }
   expect(isEqual(oldState, newState)).toBe(false)
 })
+
+test('isEqual returns false when shown severities change', () => {
+  const oldState = createDefaultState()
+  const newState = { ...oldState, showErrors: false }
+
+  expect(isEqual(oldState, newState)).toBe(false)
+})

--- a/packages/problems-view/test/DiffItems.test.ts
+++ b/packages/problems-view/test/DiffItems.test.ts
@@ -90,3 +90,10 @@ test('isEqual returns false when file icons change', () => {
 
   expect(isEqual(oldState, newState)).toBe(false)
 })
+
+test('isEqual returns false when shown severities change', () => {
+  const oldState = createDefaultState()
+  const newState = { ...oldState, showErrors: false }
+
+  expect(isEqual(oldState, newState)).toBe(false)
+})

--- a/packages/problems-view/test/FilterProblems.test.ts
+++ b/packages/problems-view/test/FilterProblems.test.ts
@@ -308,3 +308,101 @@ test('filterProblems handles multiple problems with different matches', () => {
   expect(result[0].uriMatchIndex).toBeGreaterThanOrEqual(0)
   expect(result[1].uriMatchIndex).toBeGreaterThanOrEqual(0)
 })
+
+test('filterProblems excludes errors and empty file groups when showErrors is false', () => {
+  const problems: readonly Problem[] = [
+    {
+      code: '',
+      columnIndex: 0,
+      count: 1,
+      fileName: 'error.ts',
+      level: 1,
+      listItemType: ProblemListItemType.Expanded,
+      message: '',
+      posInSet: 1,
+      relativePath: '',
+      rowIndex: 0,
+      setSize: 1,
+      source: '',
+      type: '',
+      uri: '/path/to/error.ts',
+    },
+    {
+      code: 'TS1234',
+      columnIndex: 5,
+      count: 0,
+      fileName: 'error.ts',
+      level: 2,
+      listItemType: ProblemListItemType.Item,
+      message: 'Error in file',
+      posInSet: 1,
+      relativePath: '',
+      rowIndex: 1,
+      setSize: 1,
+      source: 'TypeScript',
+      type: 'error',
+      uri: '/path/to/error.ts',
+    },
+    {
+      code: '',
+      columnIndex: 0,
+      count: 1,
+      fileName: 'warning.ts',
+      level: 1,
+      listItemType: ProblemListItemType.Expanded,
+      message: '',
+      posInSet: 1,
+      relativePath: '',
+      rowIndex: 0,
+      setSize: 1,
+      source: '',
+      type: '',
+      uri: '/path/to/warning.ts',
+    },
+    {
+      code: 'TS5678',
+      columnIndex: 5,
+      count: 0,
+      fileName: 'warning.ts',
+      level: 2,
+      listItemType: ProblemListItemType.Item,
+      message: 'Warning in file',
+      posInSet: 1,
+      relativePath: '',
+      rowIndex: 1,
+      setSize: 1,
+      source: 'TypeScript',
+      type: 'warning',
+      uri: '/path/to/warning.ts',
+    },
+  ]
+
+  const result = filterProblems(problems, [], '', false, true, true)
+
+  expect(result).toHaveLength(2)
+  expect(result.map((problem) => problem.uri)).toEqual(['/path/to/warning.ts', '/path/to/warning.ts'])
+})
+
+test('filterProblems treats non-error and non-warning diagnostics as infos', () => {
+  const problems: readonly Problem[] = [
+    {
+      code: 'TS1234',
+      columnIndex: 5,
+      count: 0,
+      fileName: 'info.ts',
+      level: 2,
+      listItemType: ProblemListItemType.Item,
+      message: 'Info in file',
+      posInSet: 1,
+      relativePath: '',
+      rowIndex: 1,
+      setSize: 1,
+      source: 'TypeScript',
+      type: 'info',
+      uri: '/path/to/info.ts',
+    },
+  ]
+
+  expect(filterProblems(problems, [], '', true, true, false)).toEqual([])
+  expect(filterProblems(problems, [], '', true, true, true)).toHaveLength(1)
+})

--- a/packages/problems-view/test/GetMenuEntries2.test.ts
+++ b/packages/problems-view/test/GetMenuEntries2.test.ts
@@ -18,8 +18,11 @@ test('getMenuEntries2 returns filter menu entries for ProblemsFilter menuId', ()
 
   expect(result.length).toBe(3)
   expect(result[0].id).toBe('show-errors')
+  expect(result[0].command).toBe('Problems.toggleShowErrors')
   expect(result[1].id).toBe('show-warnings')
+  expect(result[1].command).toBe('Problems.toggleShowWarnings')
   expect(result[2].id).toBe('show-infos')
+  expect(result[2].command).toBe('Problems.toggleShowInfos')
 })
 
 test('getMenuEntries2 works with different state values', () => {


### PR DESCRIPTION
Fix the Problems view severity filter menu so Show Errors, Show Warnings, and Show Infos execute real toggle commands and update the rendered diagnostics. Add regression coverage for hiding and restoring errors through the context menu.