### PR TITLE
feature: render problems commands directly

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 490_000
+export const threshold = 492_000
 
 export const instantiations = 5000
 

--- a/packages/problems-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/problems-view/src/parts/CommandMap/CommandMap.ts
@@ -17,6 +17,7 @@ import { handleClickMoreFilters } from '../HandleClickMoreFilters/HandleClickMor
 import { handleContextMenu } from '../HandleContextMenu/HandleContextMenu.ts'
 import * as HandleFilterInput from '../HandleFilterInput/HandleFilterInput.ts'
 import { handleIconThemeChange } from '../HandleIconThemeChange/HandleIconThemeChange.ts'
+import * as HandleMessagePort from '../HandleMessagePort/HandleMessagePort.ts'
 import { handleProblemClick } from '../HandleProblemClick/HandleProblemClick.ts'
 import { handleScrollBarCaptureLost } from '../HandleScrollBarCaptureLost/HandleScrollBarCaptureLost.ts'
 import { handleScrollBarClick } from '../HandleScrollBarClick/HandleScrollBarClick.ts'
@@ -60,6 +61,7 @@ export const commandMap = {
   'Problems.handleDiagnosticsChange': WrapCommand.wrapCommand(handleDiagnosticsChange),
   'Problems.handleFilterInput': WrapCommand.wrapCommand(HandleFilterInput.handleFilterInput),
   'Problems.handleIconThemeChange': WrapCommand.wrapCommand(handleIconThemeChange),
+  'Problems.handleMessagePort': HandleMessagePort.handleMessagePort,
   'Problems.handleScrollBarCaptureLost': WrapCommand.wrapCommand(handleScrollBarCaptureLost),
   'Problems.handleScrollBarClick': WrapCommand.wrapCommand(handleScrollBarClick),
   'Problems.handleScrollBarMove': WrapCommand.wrapCommand(handleScrollBarMove),

--- a/packages/problems-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/problems-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,0 +1,10 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+
+export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+  const rpc = await PlainMessagePortRpc.create({
+    commandMap: {},
+    messagePort: port,
+  })
+  RendererProcess.set(rpc)
+}

--- a/packages/problems-view/src/parts/Render2/Render2.ts
+++ b/packages/problems-view/src/parts/Render2/Render2.ts
@@ -1,10 +1,22 @@
+import { ViewletCommand as ViewletCommandConstants } from '@lvce-editor/constants'
 import type { ViewletCommand } from '../ViewletCommand/ViewletCommand.ts'
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
 import * as ProblemStates from '../ProblemsStates/ProblemsStates.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-export const render2 = (uid: number, diffResult: readonly number[]): readonly ViewletCommand[] => {
+const renderDirect = async (uid: number, commands: readonly ViewletCommand[]): Promise<readonly ViewletCommand[]> => {
+  const rendererWorkerCommands = commands.filter((command) => command[0] === ViewletCommandConstants.SetFocusContext)
+  const rendererProcessCommands = commands.filter((command) => command[0] !== ViewletCommandConstants.SetFocusContext)
+  const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
+  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
+}
+
+export const render2 = (uid: number, diffResult: readonly number[]): readonly ViewletCommand[] | Promise<readonly ViewletCommand[]> => {
   const { newState, oldState } = ProblemStates.get(uid)
   ProblemStates.set(uid, newState, newState)
   const commands = ApplyRender.applyRender(oldState, newState, diffResult)
-  return commands
+  if (!RendererProcess.isConnected()) {
+    return commands
+  }
+  return renderDirect(uid, commands)
 }

--- a/packages/problems-view/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/problems-view/src/parts/RendererProcess/RendererProcess.ts
@@ -1,0 +1,20 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+
+const state = {
+  connected: false,
+}
+
+export const isConnected = (): boolean => {
+  const { connected } = state
+  return connected
+}
+
+export const invoke = (method: string, ...params: readonly unknown[]): Promise<any> => {
+  return RendererProcessRegistry.invoke(method, ...params)
+}
+
+export const set = (rpc: Rpc): void => {
+  RendererProcessRegistry.set(rpc)
+  state.connected = true
+}

--- a/packages/problems-view/test/HandleMessagePort.test.ts
+++ b/packages/problems-view/test/HandleMessagePort.test.ts
@@ -1,0 +1,22 @@
+import { expect, jest, test } from '@jest/globals'
+import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+
+test('handleMessagePort connects the problems worker to the renderer process', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  const { port1, port2 } = new MessageChannel()
+  const rendererProcessRpc = await PlainMessagePortRpcParent.create({
+    commandMap: {
+      'Viewlet.queueCommands': queueCommands,
+    },
+    messagePort: port1,
+  })
+
+  await handleMessagePort(port2)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', []]])
+
+  await RendererProcess.dispose()
+  await rendererProcessRpc.dispose()
+})

--- a/packages/problems-view/test/Render2.test.ts
+++ b/packages/problems-view/test/Render2.test.ts
@@ -1,11 +1,30 @@
-import { test, expect } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
-import { set } from '../src/parts/ProblemsStates/ProblemsStates.ts'
-import { render2 } from '../src/parts/Render2/Render2.ts'
+import * as DiffType from '../src/parts/DiffType/DiffType.ts'
+import * as ProblemsStates from '../src/parts/ProblemsStates/ProblemsStates.ts'
+import * as Render2 from '../src/parts/Render2/Render2.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
-test('render2 returns ViewletCommands array', () => {
-  const state = createDefaultState()
-  set(1, state, state)
-  const result = render2(1, [])
-  expect(Array.isArray(result)).toBe(true)
+test('render2 returns renderer commands when no direct renderer is connected', () => {
+  const uid = 1
+  const oldState = createDefaultState()
+  const newState = { ...oldState, filterValue: 'error', uid }
+  ProblemsStates.set(uid, oldState, newState)
+
+  expect(Render2.render2(uid, [DiffType.RenderFilterValue])).toEqual([['Viewlet.setValueByName', 'filter', 'error']])
+})
+
+test('render2 queues renderer commands and returns a lightweight commit marker', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands } }))
+  const uid = 2
+  const oldState = createDefaultState()
+  const newState = { ...oldState, filterValue: 'error', uid }
+  ProblemsStates.set(uid, oldState, newState)
+
+  const result = await Render2.render2(uid, [DiffType.RenderFilterValue])
+
+  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.setValueByName', 'filter', 'error']])
+  expect(result).toEqual([['Viewlet.commitPending', uid, 17]])
 })


### PR DESCRIPTION
Connects the problems worker directly to the renderer process and queues render commands over the dedicated port while preserving the legacy fallback.