### PR TITLE
fix: include problems view id in render commands

### DIFF
--- a/packages/problems-view/src/parts/RenderFilterValue/RenderFilterValue.ts
+++ b/packages/problems-view/src/parts/RenderFilterValue/RenderFilterValue.ts
@@ -3,5 +3,10 @@ import type { ViewletCommand } from '../ViewletCommand/ViewletCommand.ts'
 import * as GetFilterInputName from '../GetFilterInputName/GetFilterInputName.ts'
 
 export const renderFilterValue = (oldState: ProblemsState, newState: ProblemsState): ViewletCommand => {
-  return ['Viewlet.setValueByName', GetFilterInputName.getFilterInputName(newState.inputSource, newState.filterValue), newState.filterValue]
+  return [
+    'Viewlet.setValueByName',
+    newState.uid,
+    GetFilterInputName.getFilterInputName(newState.inputSource, newState.filterValue),
+    newState.filterValue,
+  ]
 }

--- a/packages/problems-view/src/parts/RenderItems/RenderItems.ts
+++ b/packages/problems-view/src/parts/RenderItems/RenderItems.ts
@@ -60,5 +60,5 @@ export const renderItems = (oldState: ProblemsState, newState: ProblemsState): V
     scrollBarActive,
     problemCount,
   )
-  return ['Viewlet.setDom2', dom]
+  return ['Viewlet.setDom2', newState.uid, dom]
 }

--- a/packages/problems-view/test/Render2.test.ts
+++ b/packages/problems-view/test/Render2.test.ts
@@ -12,7 +12,7 @@ test('render2 returns renderer commands when no direct renderer is connected', (
   const newState = { ...oldState, filterValue: 'error', uid }
   ProblemsStates.set(uid, oldState, newState)
 
-  expect(Render2.render2(uid, [DiffType.RenderFilterValue])).toEqual([['Viewlet.setValueByName', 'filter', 'error']])
+  expect(Render2.render2(uid, [DiffType.RenderFilterValue])).toEqual([['Viewlet.setValueByName', uid, 'filter', 'error']])
 })
 
 test('render2 queues renderer commands and returns a lightweight commit marker', async () => {
@@ -25,6 +25,6 @@ test('render2 queues renderer commands and returns a lightweight commit marker',
 
   const result = await Render2.render2(uid, [DiffType.RenderFilterValue])
 
-  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.setValueByName', 'filter', 'error']])
+  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.setValueByName', uid, 'filter', 'error']])
   expect(result).toEqual([['Viewlet.commitPending', uid, 17]])
 })

--- a/packages/problems-view/test/RenderFilterValue.test.ts
+++ b/packages/problems-view/test/RenderFilterValue.test.ts
@@ -9,11 +9,12 @@ test('renderFilterValue returns correct ViewletCommand when filterValue changes'
   const newState: ProblemsState = {
     ...createDefaultState(),
     filterValue: 'test filter',
+    uid: 41,
   }
 
   const result = renderFilterValue(oldState, newState)
 
-  expect(result).toEqual(['Viewlet.setValueByName', 'filter', 'test filter'])
+  expect(result).toEqual(['Viewlet.setValueByName', 41, 'filter', 'test filter'])
 })
 
 test('renderFilterValue returns correct ViewletCommand when filterValue is empty', () => {
@@ -21,11 +22,12 @@ test('renderFilterValue returns correct ViewletCommand when filterValue is empty
   const newState: ProblemsState = {
     ...createDefaultState(),
     filterValue: '',
+    uid: 42,
   }
 
   const result = renderFilterValue(oldState, newState)
 
-  expect(result).toEqual(['Viewlet.setValueByName', 'filter', ''])
+  expect(result).toEqual(['Viewlet.setValueByName', 42, 'filter', ''])
 })
 
 test('renderFilterValue returns correct ViewletCommand when filterValue has special characters', () => {
@@ -34,9 +36,10 @@ test('renderFilterValue returns correct ViewletCommand when filterValue has spec
     ...createDefaultState(),
     filterValue: 'error: "unexpected token"',
     inputSource: InputSource.Script,
+    uid: 43,
   }
 
   const result = renderFilterValue(oldState, newState)
 
-  expect(result).toEqual(['Viewlet.setValueByName', 'filter-error%3A%20%22unexpected%20token%22', 'error: "unexpected token"'])
+  expect(result).toEqual(['Viewlet.setValueByName', 43, 'filter-error%3A%20%22unexpected%20token%22', 'error: "unexpected token"'])
 })

--- a/packages/problems-view/test/RenderItems.test.ts
+++ b/packages/problems-view/test/RenderItems.test.ts
@@ -3,8 +3,9 @@ import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaul
 import { renderItems } from '../src/parts/RenderItems/RenderItems.ts'
 
 test('renderItems returns a ViewletCommand', () => {
-  const state = createDefaultState()
+  const state = { ...createDefaultState(), uid: 44 }
   const result = renderItems(state, state)
   expect(Array.isArray(result)).toBe(true)
   expect(result[0]).toBe('Viewlet.setDom2')
+  expect(result[1]).toBe(44)
 })


### PR DESCRIPTION
## Summary

- include the Problems view UID in direct `Viewlet.setDom2` commands
- include the UID in direct filter-value updates
- assert the full renderer-process command protocol in unit tests

## Root cause

Problems View 1.31.0 started queueing render commands directly in the renderer process, whose handlers require the target view UID. The Problems commands omitted that UID, so diagnostic counts updated while the renderer could not update the Problems DOM.

## Validation

- `npm test` (83 suites, 325 passed, 1 todo)
- `npm run type-check`
- `npm run lint`
- local LVCE Electron integration: TypeScript diagnostic rows render and filtering leaves the matching row