### PR TITLE
fix: handle missing active editor

### DIFF
--- a/packages/e2e/src/problems.open-without-editor.ts
+++ b/packages/e2e/src/problems.open-without-editor.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.open-without-editor'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Panel }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const fileUri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(fileUri, 'content')
+  await Main.openUri(fileUri)
+  await Main.closeAllEditors()
+
+  await Panel.openProblems()
+
+  const problemsView = Locator('.Viewlet.Problems')
+  await expect(problemsView).toBeVisible()
+  await expect(problemsView).toHaveAttribute('data-active-uri', '')
+  await expect(problemsView).toHaveText('No problems have been detected in the workspace.')
+}

--- a/packages/problems-view/src/parts/GetActiveUri/GetActiveUri.ts
+++ b/packages/problems-view/src/parts/GetActiveUri/GetActiveUri.ts
@@ -6,5 +6,9 @@ export const getActiveUri = async (): Promise<string> => {
   if (editorId === -1) {
     return ''
   }
-  return EditorWorker.getUri(editorId)
+  try {
+    return await EditorWorker.getUri(editorId)
+  } catch {
+    return ''
+  }
 }

--- a/packages/problems-view/test/GetActiveUri.test.ts
+++ b/packages/problems-view/test/GetActiveUri.test.ts
@@ -25,3 +25,17 @@ test('returns an empty uri when there is no active editor', async () => {
   expect(rendererRpc.invocations).toEqual([['GetActiveEditor.getActiveEditorId']])
   expect(editorRpc.invocations).toEqual([])
 })
+
+test('returns an empty uri when the active editor was disposed', async () => {
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'GetActiveEditor.getActiveEditorId': () => 42,
+  })
+  using editorRpc = EditorWorker.registerMockRpc({
+    'Editor.getUri': () => {
+      throw new Error('editor 42 not found')
+    },
+  })
+  await expect(getActiveUri()).resolves.toBe('')
+  expect(rendererRpc.invocations).toEqual([['GetActiveEditor.getActiveEditorId']])
+  expect(editorRpc.invocations).toEqual([['Editor.getUri', 42]])
+})


### PR DESCRIPTION
Opening the Problems view now treats a disposed active editor as no active editor instead of surfacing an editor-not-found error. Adds unit and end-to-end regression coverage for opening Problems after all editors are closed.