### PR TITLE
fix: show collapsed problems in table view

### DIFF
--- a/packages/e2e/src/problems.toolbar-actions.ts
+++ b/packages/e2e/src/problems.toolbar-actions.ts
@@ -43,6 +43,12 @@ export const test: Test = async ({ expect, Extension, FileSystem, Locator, Main,
   await collapseAll.click()
   await waitFor(() => expect(problems).toHaveCount(1))
 
+  // eslint-disable-next-line e2e/no-direct-click -- This regression test must exercise the rendered Problems action after collapsing the list.
+  await viewAsTable.click()
+  await waitFor(() => expect(problemsTable).toBeVisible())
+  const tableRows = problemsTable.locator('.ProblemsTableBody .ProblemsTableRow')
+  await expect(tableRows).toHaveCount(1)
+
   const moreFilters = Locator('button[title="more filters"]')
   // eslint-disable-next-line e2e/no-direct-click -- This regression test must exercise the rendered Problems action instead of its command API.
   await moreFilters.click()

--- a/packages/problems-view/src/parts/GetVisibleProblemCount/GetVisibleProblemCount.ts
+++ b/packages/problems-view/src/parts/GetVisibleProblemCount/GetVisibleProblemCount.ts
@@ -11,7 +11,8 @@ export const getVisibleProblemCount = (
   showWarnings = true,
   showInfos = true,
 ): number => {
-  const filtered = FilterProblems.filterProblems(problems, collapsedUris, filterValue, showErrors, showWarnings, showInfos)
+  const effectiveCollapsedUris = viewMode === ProblemsViewMode.Table ? [] : collapsedUris
+  const filtered = FilterProblems.filterProblems(problems, effectiveCollapsedUris, filterValue, showErrors, showWarnings, showInfos)
   if (viewMode !== ProblemsViewMode.Table) {
     return filtered.length
   }

--- a/packages/problems-view/src/parts/GetVisibleProblems/GetVisibleProblems.ts
+++ b/packages/problems-view/src/parts/GetVisibleProblems/GetVisibleProblems.ts
@@ -25,7 +25,8 @@ export const getVisibleProblems = (
   Assert.string(filterValue)
   const visibleItems = []
   const filterValueLength = filterValue.length
-  const filtered = FilterProblems.filterProblems(problems, collapsedUris, filterValue, showErrors, showWarnings, showInfos)
+  const effectiveCollapsedUris = viewMode === ProblemsViewMode.Table ? [] : collapsedUris
+  const filtered = FilterProblems.filterProblems(problems, effectiveCollapsedUris, filterValue, showErrors, showWarnings, showInfos)
   const displayProblems = viewMode === ProblemsViewMode.Table ? filtered.filter((problem) => problem.message) : filtered
   const finalLineY = Math.min(maxLineY, displayProblems.length)
   for (let i = minLineY; i < finalLineY; i++) {

--- a/packages/problems-view/test/GetVisibleProblems.test.ts
+++ b/packages/problems-view/test/GetVisibleProblems.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@jest/globals'
+import type { Problem } from '../src/parts/Problem/Problem.ts'
+import { getVisibleProblems } from '../src/parts/GetVisibleProblems/GetVisibleProblems.ts'
+import * as ProblemListItemType from '../src/parts/ProblemListItemType/ProblemListItemType.ts'
+import * as ProblemsViewMode from '../src/parts/ProblemsViewMode/ProblemsViewMode.ts'
+
+const createProblem = (listItemType: number, message: string): Problem => ({
+  code: 'test',
+  columnIndex: 1,
+  count: 1,
+  fileName: 'file.ts',
+  level: listItemType === ProblemListItemType.Item ? 2 : 1,
+  listItemType,
+  message,
+  posInSet: 1,
+  relativePath: 'file.ts',
+  rowIndex: 1,
+  setSize: 1,
+  source: 'test',
+  type: 'error',
+  uri: 'file:///file.ts',
+})
+
+test('table mode includes problems from collapsed list groups', () => {
+  const problems = [createProblem(ProblemListItemType.Expanded, ''), createProblem(ProblemListItemType.Item, 'problem')]
+
+  const result = getVisibleProblems(problems, {}, ['file:///file.ts'], -1, '', 0, Infinity, ProblemsViewMode.Table)
+
+  expect(result).toHaveLength(1)
+  expect(result[0].message).toBe('problem')
+})

--- a/packages/problems-view/test/UpdateVirtualList.test.ts
+++ b/packages/problems-view/test/UpdateVirtualList.test.ts
@@ -85,6 +85,31 @@ test('updateVirtualList excludes group rows in table mode', () => {
   expect(newState.maxLineY).toBe(2)
 })
 
+test('updateVirtualList includes problems from collapsed list groups in table mode', () => {
+  const group = {
+    ...createProblem(0),
+    level: 1,
+    listItemType: 1,
+    message: '',
+  }
+  const firstProblem = { ...createProblem(1), uri: group.uri }
+  const secondProblem = { ...createProblem(2), uri: group.uri }
+  const state = {
+    ...createDefaultState(),
+    collapsedUris: [group.uri],
+    height: 42,
+    itemHeight: 20,
+    problems: [group, firstProblem, secondProblem],
+    viewMode: ProblemsViewMode.Table,
+    width: 800,
+  }
+
+  const newState = updateVirtualList(state)
+
+  expect(newState.finalDeltaY).toBe(20)
+  expect(newState.maxLineY).toBe(2)
+})
+
 test('updateVirtualList accounts for the narrow-width filter', () => {
   const problems = Array.from({ length: 10 }, (_, index) => createProblem(index))
   const state = {


### PR DESCRIPTION
## Summary

- ignore list-only collapsed groups when rendering Problems table rows
- keep table virtual-list sizing consistent with rendered diagnostics
- add unit and end-to-end coverage for Collapse All followed by View as Table

## Testing

- `npm test`
- `npm run type-check`
- `npm run lint`
- `npm run e2e:headless --workspace=packages/e2e -- --filter=problems.toolbar-actions`