### PR TITLE
feature: handle view events directly

### DIFF
--- a/packages/problems-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/problems-view/src/parts/CommandMap/CommandMap.ts
@@ -39,6 +39,8 @@ import { toggleShowWarnings } from '../ToggleShowWarnings/ToggleShowWarnings.ts'
 import { viewAsList } from '../ViewAsList/ViewAsList.ts'
 import { viewAsTable } from '../ViewAsTable/ViewAsTable.ts'
 
+const handleDirectMessagePort = (port: MessagePort): Promise<void> => HandleMessagePort.handleMessagePort(port, commandMap)
+
 export const commandMap = {
   'Problems.collapseAll': WrapCommand.wrapCommand(collapseAll),
   'Problems.copyMessage': WrapCommand.wrapCommand(CopyMessage.copyMessage),
@@ -61,7 +63,7 @@ export const commandMap = {
   'Problems.handleDiagnosticsChange': WrapCommand.wrapCommand(handleDiagnosticsChange),
   'Problems.handleFilterInput': WrapCommand.wrapCommand(HandleFilterInput.handleFilterInput),
   'Problems.handleIconThemeChange': WrapCommand.wrapCommand(handleIconThemeChange),
-  'Problems.handleMessagePort': HandleMessagePort.handleMessagePort,
+  'Problems.handleMessagePort': handleDirectMessagePort,
   'Problems.handleScrollBarCaptureLost': WrapCommand.wrapCommand(handleScrollBarCaptureLost),
   'Problems.handleScrollBarClick': WrapCommand.wrapCommand(handleScrollBarClick),
   'Problems.handleScrollBarMove': WrapCommand.wrapCommand(handleScrollBarMove),

--- a/packages/problems-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/problems-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,9 +1,21 @@
 import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+export const handleMessagePort = async (port: MessagePort, viewletCommandMap: Readonly<Record<string, unknown>>): Promise<void> => {
+  const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
+    const fn = viewletCommandMap[`Problems.${command}`]
+    if (typeof fn !== 'function') {
+      throw new TypeError(`Viewlet command not found: ${command}`)
+    }
+    await fn(uid, ...args)
+    await RendererWorker.invoke('Viewlet.requestRender', uid)
+  }
+
   const rpc = await PlainMessagePortRpc.create({
-    commandMap: {},
+    commandMap: {
+      'Viewlet.executeViewletCommand': executeViewletCommand,
+    },
     messagePort: port,
   })
   RendererProcess.set(rpc)

--- a/packages/problems-view/test/HandleMessagePort.test.ts
+++ b/packages/problems-view/test/HandleMessagePort.test.ts
@@ -1,22 +1,42 @@
 import { expect, jest, test } from '@jest/globals'
-import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
-import { RendererProcess } from '@lvce-editor/rpc-registry'
+import { createMockRpc, PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry, RendererWorker } from '@lvce-editor/rpc-registry'
 import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
-test('handleMessagePort connects the problems worker to the renderer process', async () => {
+test('connects the view directly to the renderer process', async () => {
   const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
   const { port1, port2 } = new MessageChannel()
   const rendererProcessRpc = await PlainMessagePortRpcParent.create({
-    commandMap: {
-      'Viewlet.queueCommands': queueCommands,
-    },
+    commandMap: { 'Viewlet.queueCommands': queueCommands },
     messagePort: port1,
   })
+  const handleEvent = jest.fn(async (_uid: number, _value: string) => {})
 
-  await handleMessagePort(port2)
-  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', []]])).resolves.toBe(31)
-  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', []]])
+  await handleMessagePort(port2, {
+    'Problems.handleEvent': handleEvent,
+  })
+  expect(RendererProcess.isConnected()).toBe(true)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
 
-  await RendererProcess.dispose()
+  const requestRender = jest.fn(async (_uid: number) => {})
+  RendererWorker.set(
+    Object.assign(
+      createMockRpc({
+        commandMap: {
+          'Viewlet.requestRender': requestRender,
+        },
+      }),
+      { dispose: jest.fn() },
+    ),
+  )
+  await rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'handleEvent', 'hello')
+  expect(handleEvent).toHaveBeenCalledWith(7, 'hello')
+  expect(requestRender).toHaveBeenCalledWith(7)
+  await expect(rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'missing')).rejects.toThrow('Viewlet command not found: missing')
+
+  await RendererProcessRegistry.dispose()
+  await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })


### PR DESCRIPTION
## Summary
- expose direct renderer-process DOM event handling on the view port
- update view state in the owning worker and request a renderer-worker diff/render
- defer command-map capture until the direct port is connected

## Tests
- npm run type-check
- focused direct message-port test
- full repository test suite