### PR TITLE
fix: preserve problems count for disposed editor

### DIFF
--- a/packages/problems-view/src/parts/GetProblemsSummary/GetProblemsSummary.ts
+++ b/packages/problems-view/src/parts/GetProblemsSummary/GetProblemsSummary.ts
@@ -9,6 +9,14 @@ const countByType = (diagnostics: readonly Diagnostic[], type: string): number =
   return diagnostics.filter((diagnostic) => diagnostic.type === type).length
 }
 
+const getActiveDiagnostics = async (editorId: number): Promise<readonly Diagnostic[]> => {
+  try {
+    return await EditorWorker.getDiagnostics(editorId)
+  } catch {
+    return []
+  }
+}
+
 export const getProblemsSummary = async (): Promise<ProblemsSummary> => {
   const editorId = await RendererWorker.getActiveEditorId()
   if (editorId === -1) {
@@ -19,7 +27,7 @@ export const getProblemsSummary = async (): Promise<ProblemsSummary> => {
       warningCount: 0,
     }
   }
-  const [allDiagnostics, activeDiagnostics] = await Promise.all([EditorWorker.getProblems(), EditorWorker.getDiagnostics(editorId)])
+  const [allDiagnostics, activeDiagnostics] = await Promise.all([EditorWorker.getProblems(), getActiveDiagnostics(editorId)])
   const uniqueDiagnostics = getUniqueDiagnostics(allDiagnostics)
   const uniqueActiveDiagnostics = getUniqueDiagnostics(activeDiagnostics)
   return {

--- a/packages/problems-view/test/GetProblemsSummary.test.ts
+++ b/packages/problems-view/test/GetProblemsSummary.test.ts
@@ -48,3 +48,32 @@ test('returns the total problem count and active editor severity counts', async 
   expect(rendererRpc.invocations).toEqual([['GetActiveEditor.getActiveEditorId']])
   expect(editorRpc.invocations).toEqual([['Editor.getProblems'], ['Editor.getDiagnostics', 7]])
 })
+
+test('returns the total problem count when the active editor was disposed', async () => {
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'GetActiveEditor.getActiveEditorId': () => 7,
+  })
+  const problem = {
+    code: '',
+    columnIndex: 0,
+    message: 'missing semicolon',
+    rowIndex: 0,
+    source: 'eslint',
+    type: 'error',
+    uri: 'file:///active.js',
+  }
+  using editorRpc = EditorWorker.registerMockRpc({
+    'Editor.getDiagnostics': () => {
+      throw new Error('editor 7 not found')
+    },
+    'Editor.getProblems': () => [problem],
+  })
+  await expect(getProblemsSummary()).resolves.toEqual({
+    errorCount: 0,
+    hasEditor: true,
+    problemCount: 1,
+    warningCount: 0,
+  })
+  expect(rendererRpc.invocations).toEqual([['GetActiveEditor.getActiveEditorId']])
+  expect(editorRpc.invocations).toEqual([['Editor.getProblems'], ['Editor.getDiagnostics', 7]])
+})


### PR DESCRIPTION
## Summary

- keep the workspace problem count available when an active editor is disposed during a diagnostics update
- isolate the active-editor severity lookup so a stale editor cannot drop the entire Problems summary
- add a regression test for the disposed-editor race

## Tests

- `npm test`
- `npm run lint`
- `npm run type-check`