### PR TITLE
feature: show related diagnostic locations

### DIFF
--- a/packages/build/src/buildE2eExtensions.ts
+++ b/packages/build/src/buildE2eExtensions.ts
@@ -18,4 +18,5 @@ const buildE2eExtension = async (extensionName: string): Promise<void> => {
 export const buildE2eExtensions = async (): Promise<void> => {
   await buildE2eExtension('problems.click-focuses-editor')
   await buildE2eExtension('problems.one-problem')
+  await buildE2eExtension('problems.related-location')
 }

--- a/packages/e2e/fixtures/problems.related-location/extension.json
+++ b/packages/e2e/fixtures/problems.related-location/extension.json
@@ -1,0 +1,17 @@
+{
+  "browser": "dist/main.js",
+  "isolated": true,
+  "diagnosticProviders": [
+    {
+      "id": "xyz-diagnostics",
+      "languageId": "xyz"
+    }
+  ],
+  "languages": [
+    {
+      "id": "xyz",
+      "extensions": [".xyz"]
+    }
+  ],
+  "activation": ["onDiagnostic:xyz"]
+}

--- a/packages/e2e/fixtures/problems.related-location/main.js
+++ b/packages/e2e/fixtures/problems.related-location/main.js
@@ -1,0 +1,34 @@
+import { activate as activateExtensionApi, registerDiagnosticProvider } from '@lvce-editor/api'
+
+const diagnosticProvider = {
+  id: 'xyz-diagnostics',
+  languageId: 'xyz',
+  provideDiagnostics(textDocument) {
+    const targetUri = textDocument.uri.replace('main.xyz', 'types.xyz')
+    return [
+      {
+        uri: textDocument.uri,
+        rowIndex: 0,
+        columnIndex: 0,
+        endRowIndex: 0,
+        endColumnIndex: 5,
+        message: 'Type mismatch',
+        relatedInformation: [
+          {
+            uri: targetUri,
+            rowIndex: 1,
+            columnIndex: 0,
+            endRowIndex: 1,
+            endColumnIndex: 6,
+            message: 'The expected type is declared here',
+          },
+        ],
+        source: 'xyz',
+        type: 'error',
+      },
+    ]
+  },
+}
+
+await activateExtensionApi()
+registerDiagnosticProvider(diagnosticProvider)

--- a/packages/e2e/src/problems.related-location.ts
+++ b/packages/e2e/src/problems.related-location.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'problems.related-location'
+
+export const test: Test = async ({ Editor, expect, Extension, FileSystem, Locator, Main, Panel, Problems, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const mainUri = `${tmpDir}/main.xyz`
+  const typesUri = `${tmpDir}/types.xyz`
+  await FileSystem.setFiles([
+    { content: 'value', uri: mainUri },
+    { content: 'first line\ntarget declaration', uri: typesUri },
+  ])
+  await Workspace.setPath(tmpDir)
+  // @ts-ignore
+  await Extension.addWebExtension(new URL(`../fixtures/${name}`, import.meta.url).toString())
+  await Main.openUri(mainUri)
+  await Panel.openProblems()
+
+  const problems = Locator('.Problem')
+  await expect(problems).toHaveCount(3)
+  await expect(problems.nth(2)).toContainText('The expected type is declared here')
+  await expect(problems.nth(2)).toContainText('types.xyz')
+
+  await Problems.handleClickAt(10, 638)
+
+  await Editor.shouldHaveText('first line\ntarget declaration')
+  await Editor.shouldHaveSelections(new Uint32Array([1, 0, 1, 0]))
+}

--- a/packages/problems-view/src/parts/Diagnostic/Diagnostic.ts
+++ b/packages/problems-view/src/parts/Diagnostic/Diagnostic.ts
@@ -3,9 +3,19 @@ export interface Diagnostic {
   readonly columnIndex: number
   readonly listItemType: number
   readonly message: string
+  readonly relatedInformation?: readonly RelatedDiagnosticInformation[]
   readonly relativePath: string
   readonly rowIndex: number
   readonly source: string
   readonly type: string
+  readonly uri: string
+}
+
+export interface RelatedDiagnosticInformation {
+  readonly columnIndex: number
+  readonly endColumnIndex: number
+  readonly endRowIndex: number
+  readonly message: string
+  readonly rowIndex: number
   readonly uri: string
 }

--- a/packages/problems-view/src/parts/GetProblemIndent/GetProblemIndent.ts
+++ b/packages/problems-view/src/parts/GetProblemIndent/GetProblemIndent.ts
@@ -1,8 +1,8 @@
 import * as GetTreeItemIndent from '../GetTreeItemIndent/GetTreeItemIndent.ts'
 import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType.ts'
 
-export const getProblemIndent = (listItemType: number): string => {
+export const getProblemIndent = (listItemType: number, level?: number): string => {
   const isGroup = listItemType === ProblemListItemType.Expanded || listItemType === ProblemListItemType.Collapsed
-  const depth = isGroup ? 1 : 2
+  const depth = isGroup ? 1 : Math.max(2, level || 2)
   return GetTreeItemIndent.getTreeItemIndent(depth)
 }

--- a/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
@@ -57,7 +57,7 @@ export const getProblemVirtualDom = (problem: VisibleProblem): readonly VirtualD
     uri,
   } = problem
   let className = ClassNames.Problem
-  const indent = GetProblemIndent.getProblemIndent(listItemType)
+  const indent = GetProblemIndent.getProblemIndent(listItemType, level)
   className = mergeClassNames(className, `Indent-${indent}`)
   if (isActive) {
     className = mergeClassNames(className, ClassNames.ProblemSelected)

--- a/packages/problems-view/src/parts/GetUniqueIndents/GetUniqueIndents.ts
+++ b/packages/problems-view/src/parts/GetUniqueIndents/GetUniqueIndents.ts
@@ -4,7 +4,7 @@ import * as GetProblemIndent from '../GetProblemIndent/GetProblemIndent.ts'
 export const getUniqueIndents = (problems: readonly VisibleProblem[]): readonly string[] => {
   const uniqueIndents: string[] = []
   for (const problem of problems) {
-    const indent = GetProblemIndent.getProblemIndent(problem.listItemType)
+    const indent = GetProblemIndent.getProblemIndent(problem.listItemType, problem.level)
     if (!uniqueIndents.includes(indent)) {
       uniqueIndents.push(indent)
     }

--- a/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
+++ b/packages/problems-view/src/parts/HandleProblemClick/HandleProblemClick.ts
@@ -28,8 +28,8 @@ export const handleProblemClick = async (state: ProblemsState, eventX: number, e
   if (!problem || problem.listItemType !== ProblemListItemType.Item) {
     return newState
   }
-  const { columnIndex, rowIndex, uri } = problem
-  await RendererWorker.openUri(uri, true)
+  const { columnIndex, rowIndex, targetUri, uri } = problem
+  await RendererWorker.openUri(targetUri || uri, true)
   await RendererWorker.focusEditor()
   await RendererWorker.setEditorCursor(rowIndex, columnIndex)
   return newState

--- a/packages/problems-view/src/parts/Problem/Problem.ts
+++ b/packages/problems-view/src/parts/Problem/Problem.ts
@@ -11,6 +11,7 @@ export interface Problem {
   readonly rowIndex: number
   readonly setSize: number
   readonly source: string
+  readonly targetUri?: string
   readonly type: string
   readonly uri: string
 }

--- a/packages/problems-view/src/parts/ToProblems/ToProblems.ts
+++ b/packages/problems-view/src/parts/ToProblems/ToProblems.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from '../Diagnostic/Diagnostic.ts'
+import type { Diagnostic, RelatedDiagnosticInformation } from '../Diagnostic/Diagnostic.ts'
 import type { Problem } from '../Problem/Problem.ts'
 import * as ProblemListItemType from '../ProblemListItemType/ProblemListItemType.ts'
 
@@ -6,7 +6,7 @@ const leadingSlashesRegex = /^\/+/
 const trailingSlashRegex = /\/$/
 const windowsDrivePathRegex = /^\/[a-z]:\//i
 
-const toProblem = (diagnostic: Diagnostic, index: number): Problem => {
+const toProblem = (diagnostic: Diagnostic, index: number): DeepMutable<Problem> => {
   const { code, columnIndex, message, rowIndex, source, type, uri } = diagnostic
   return {
     code: code || '',
@@ -50,10 +50,35 @@ const getFileName = (uri: string): string => {
   return uri.slice(slashIndex + 1)
 }
 
+const toRelatedProblem = (
+  relatedInformation: RelatedDiagnosticInformation,
+  diagnostic: Diagnostic,
+  index: number,
+  setSize: number,
+): DeepMutable<Problem> => {
+  return {
+    code: '',
+    columnIndex: relatedInformation.columnIndex || 0,
+    count: 0,
+    fileName: '',
+    level: 3,
+    listItemType: ProblemListItemType.Item,
+    message: relatedInformation.message || '',
+    posInSet: index,
+    relativePath: '',
+    rowIndex: relatedInformation.rowIndex || 0,
+    setSize,
+    source: getFileName(relatedInformation.uri),
+    targetUri: relatedInformation.uri,
+    type: diagnostic.type || 'error',
+    uri: diagnostic.uri,
+  }
+}
+
 type DeepMutable<T> = { -readonly [P in keyof T]: DeepMutable<T[P]> }
 
 export const toProblems = (diagnostics: readonly Diagnostic[], workspaceUri = ''): readonly Problem[] => {
-  const problems = []
+  const problems: DeepMutable<Problem>[] = []
   let problem: DeepMutable<Problem> = {
     code: '',
     columnIndex: 0,
@@ -96,13 +121,18 @@ export const toProblems = (diagnostics: readonly Diagnostic[], workspaceUri = ''
       problems.push(problem)
     }
     problems.push(toProblem(diagnostic, relativeIndex))
+    const relatedInformation = diagnostic.relatedInformation || []
+    for (let i = 0; i < relatedInformation.length; i++) {
+      problems.push(toRelatedProblem(relatedInformation[i], diagnostic, i + 1, relatedInformation.length))
+    }
   }
   for (const problem of problems) {
     // TODO maybe rename property, this should be the relative path of the parent folder of the file
     // @ts-ignore
-    problem.relativePath = getRelativeParentUri(problem.uri, workspaceUri)
+    const displayUri = problem.targetUri || problem.uri
+    problem.relativePath = getRelativeParentUri(displayUri, workspaceUri)
     // @ts-ignore
-    problem.fileName = getFileName(problem.uri)
+    problem.fileName = getFileName(displayUri)
     // problem.uri = problem.uri // TODO
   }
   return problems

--- a/packages/problems-view/test/GetProblemIndent.test.ts
+++ b/packages/problems-view/test/GetProblemIndent.test.ts
@@ -13,3 +13,7 @@ test('getProblemIndent returns one rem for collapsed groups', () => {
 test('getProblemIndent returns two rem for problem items', () => {
   expect(getProblemIndent(ProblemListItemType.Item)).toBe('2rem')
 })
+
+test('getProblemIndent uses the tree level for related diagnostic items', () => {
+  expect(getProblemIndent(ProblemListItemType.Item, 3)).toBe('3rem')
+})

--- a/packages/problems-view/test/HandleProblemClick.test.ts
+++ b/packages/problems-view/test/HandleProblemClick.test.ts
@@ -81,3 +81,44 @@ test('does not open a file when clicking a problem group', async () => {
   expect(result.focusedIndex).toBe(0)
   expect(rendererRpc.invocations).toEqual([])
 })
+
+test('opens a related diagnostic target', async () => {
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'Editor.cursorSet': async () => {},
+    'Main.focus': async () => {},
+    'Main.openUri': async () => {},
+  })
+  const state: ProblemsState = {
+    ...createDefaultState(),
+    itemHeight: 22,
+    problems: [
+      {
+        code: '',
+        columnIndex: 2,
+        count: 0,
+        fileName: 'types.ts',
+        level: 3,
+        listItemType: ProblemListItemType.Item,
+        message: 'The expected type comes from here.',
+        posInSet: 1,
+        relativePath: '',
+        rowIndex: 1,
+        setSize: 1,
+        source: 'types.ts',
+        targetUri: 'file:///workspace/types.ts',
+        type: 'error',
+        uri: 'file:///workspace/main.ts',
+      },
+    ],
+    viewMode: ProblemsViewMode.List,
+    width: 800,
+  }
+
+  await handleProblemClick(state, 50, 11)
+
+  expect(rendererRpc.invocations).toEqual([
+    ['Main.openUri', { focus: true, uri: 'file:///workspace/types.ts' }],
+    ['Main.focus'],
+    ['Editor.cursorSet', 1, 2],
+  ])
+})

--- a/packages/problems-view/test/ToProblems.test.ts
+++ b/packages/problems-view/test/ToProblems.test.ts
@@ -164,3 +164,48 @@ test('toProblems increments relativeIndex and count for multiple diagnostics wit
   expect(itemProblems[1].posInSet).toBe(2)
   expect(itemProblems[2].posInSet).toBe(3)
 })
+
+test('toProblems adds related locations beneath their diagnostic without increasing the problem count', () => {
+  const diagnostics = [
+    {
+      code: 2322,
+      columnIndex: 8,
+      message: "Type 'number' is not assignable to type 'string'.",
+      relatedInformation: [
+        {
+          columnIndex: 2,
+          endColumnIndex: 6,
+          endRowIndex: 1,
+          message: "The expected type comes from property 'name'.",
+          rowIndex: 1,
+          uri: 'file:///workspace/types.ts',
+        },
+      ],
+      rowIndex: 4,
+      source: 'ts',
+      type: 'error',
+      uri: 'file:///workspace/main.ts',
+    },
+  ] as any
+
+  const problems = toProblems(diagnostics, 'file:///workspace')
+
+  expect(problems[0].count).toBe(1)
+  expect(problems[2]).toEqual({
+    code: '',
+    columnIndex: 2,
+    count: 0,
+    fileName: 'types.ts',
+    level: 3,
+    listItemType: 0,
+    message: "The expected type comes from property 'name'.",
+    posInSet: 1,
+    relativePath: '',
+    rowIndex: 1,
+    setSize: 1,
+    source: 'types.ts',
+    targetUri: 'file:///workspace/types.ts',
+    type: 'error',
+    uri: 'file:///workspace/main.ts',
+  })
+})


### PR DESCRIPTION
## Summary

- render diagnostic related information as nested Problems rows
- keep related rows grouped and collapsed with their parent diagnostic file
- show the related filename and location, and navigate to the related file/range on click
- keep badge/summary counts based on primary diagnostics only

## Verification

- `npm test` (84 suites; 333 passing, 1 todo)
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run build:static`
- full problems e2e suite: 159 passed, 4 skipped; the new test initially exposed an unbuilt fixture
- `--filter=problems.related-location`: 1 passed after adding the fixture to the build
- `npm run measure`: 486,244 bytes used