### PR TITLE
fix: don't render empty file icons

### DIFF
--- a/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
+++ b/packages/problems-view/src/parts/GetProblemsListItemVirtualDom/GetProblemsListItemVirtualDom.ts
@@ -63,6 +63,7 @@ export const getProblemVirtualDom = (problem: VisibleProblem): readonly VirtualD
     className = mergeClassNames(className, ClassNames.ProblemSelected)
   }
   if (listItemType === ProblemListItemType.Expanded || listItemType === ProblemListItemType.Collapsed) {
+    const fileIconDom = icon ? [GetFileIconVirtualDom.getFileIconVirtualDom(icon)] : []
     return [
       {
         ariaExpanded: !isCollapsed,
@@ -70,7 +71,7 @@ export const getProblemVirtualDom = (problem: VisibleProblem): readonly VirtualD
         ariaPosInSet: posInSet,
         ariaSelected: isActive,
         ariaSetSize: setSize,
-        childCount: 5,
+        childCount: 4 + fileIconDom.length,
         className,
         role: AriaRoles.TreeItem,
         type: VirtualDomElements.Div,
@@ -78,7 +79,7 @@ export const getProblemVirtualDom = (problem: VisibleProblem): readonly VirtualD
       listItemType === ProblemListItemType.Collapsed
         ? GetChevronVirtualDom.getChevronRightVirtualDom()
         : GetChevronVirtualDom.getChevronDownVirtualDom(),
-      GetFileIconVirtualDom.getFileIconVirtualDom(icon),
+      ...fileIconDom,
       {
         ...labelNode,
         'data-uri': uri,

--- a/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
+++ b/packages/problems-view/test/GetProblemsListItemVirtualDom.test.ts
@@ -170,6 +170,23 @@ test('getProblemVirtualDom returns correct dom for Collapsed', () => {
   expect(dom).toEqual(expectedDom)
 })
 
+test('getProblemVirtualDom does not render an empty file icon', () => {
+  const problem: VisibleProblem = {
+    ...baseProblem,
+    filterValueLength: 0,
+    icon: '',
+    isActive: false,
+    isCollapsed: true,
+    isEven: true,
+    listItemType: ProblemListItemType.Collapsed,
+  }
+
+  const dom = getProblemVirtualDom(problem)
+
+  expect(dom[0].childCount).toBe(4)
+  expect(dom.some((node) => node.className === ClassNames.FileIcon)).toBe(false)
+})
+
 test('getProblemVirtualDom returns correct dom for Item without filter highlight', () => {
   const problem: VisibleProblem = {
     ...baseProblem,


### PR DESCRIPTION
## Summary

- omit Problems file icon nodes when the icon URL is empty
- keep tree item child counts aligned with rendered children
- add regression coverage for disabled file icons

## Testing

- npm test
- npm run lint
- npm run type-check